### PR TITLE
Rework tech stack presentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS Instructions
+
+## Scope
+These instructions apply to the entire repository.
+
+## Project Overview
+This project is a fully static résumé site. Everything runs in the browser with plain HTML, CSS, and JavaScript that work when the files are served from a basic static web host.
+
+## Tooling & Dependencies
+- Keep the stack simple: do not add frontend frameworks, component compilers, build pipelines, or runtime dependencies (React, Vue, Angular, Webpack, Vite, etc.).
+- Stick to vanilla ES6 modules/DOM APIs, hand-authored HTML, and plain CSS (optionally generated from the existing SCSS files).
+- Third-party assets already in the project (Bootstrap CSS, Bootstrap Icons, Font Awesome) may be used as-is, but avoid introducing new library CDNs unless absolutely necessary.
+
+## HTML Guidelines
+- Preserve semantic markup and the existing document outline.
+- Many elements are referenced by `assets/js/i18n.js` via hard-coded IDs (e.g., `language-select`, `resume-name`, `experience-timeline`, etc.). Do not rename or remove these IDs without updating the script and the translations accordingly.
+- Keep accessibility attributes (alt text, aria labels, roles) accurate whenever you change content.
+
+## CSS/SCSS Guidelines
+- The shipped stylesheet lives in `assets/css/shine.css`; edit it directly for small tweaks.
+- If you choose to modify the SCSS sources in `assets/scss/`, make sure you also update the compiled CSS so that the site reflects your changes.
+- Keep the layout responsive and mobile-friendly; test at multiple viewport widths when you adjust styling.
+
+## JavaScript Guidelines
+- All behaviour is implemented with vanilla JS in `assets/js/i18n.js`. Extend it using the same style (modular functions, early returns for null checks, no transpilation-only syntax).
+- Avoid introducing global variables unless they are needed by the HTML; prefer module-scoped helpers.
+- Maintain graceful error handling for network operations (language file fetches, etc.).
+
+## Localization Content
+- Language data lives in `assets/lang/*.json`. When you add or edit content, keep keys consistent across all language files.
+- Ensure each language file includes the metadata section used for `<title>` and `<meta>` tags so they remain localized.
+
+## Assets
+- Place new static assets under `assets/images/` and reference them with relative paths.
+- Compress large images before committing to keep the repository lightweight.
+
+## Testing & Preview
+- There are no automated tests. Manually preview the site by serving the repository via a simple static server (for example, `python3 -m http.server`) and inspecting it in a browser.

--- a/README.md
+++ b/README.md
@@ -1,48 +1,64 @@
-<a href="https://themes.3rdwavemedia.com/bootstrap-templates/resume/shine-free-bootstrap-5-light-mode-resume-cv-template-for-developers/" target="_blank"><img src="https://themes.3rdwavemedia.com/wp-content/uploads/2023/06/free-bootstrap-resume-theme-shine-promo.jpg" alt="Shine - Bootstrap 5 Light Mode Resume/CV Template for Software Developers" /></a>
+# Patrick Nüser – Resume Website
 
-## Theme Details & Demo
+## Overview
+This repository contains the source of Patrick Nüser's online CV, a fully static single-page site that renders resume content dynamically at runtime. The page is powered by Bootstrap 5 styling, Bootstrap Icons, and a bundled Font Awesome script, and it loads its main stylesheet (`assets/css/shine.css`) and behaviour script (`assets/js/i18n.js`) directly from the `index.html` entry point.
 
-**Demo:** https://themes.3rdwavemedia.com/demo/bs5/shine/
+## Tech stack & architecture
+- **Static HTML shell** – `index.html` provides the structural markup for the resume sections (profile, experience, skills, projects, education, languages, interests) and wires up external assets such as Google Fonts, Bootstrap Icons, Font Awesome, and the theme CSS.
+- **Data-driven localisation** – `assets/js/i18n.js` fetches language JSON files, caches them, and fills the DOM on load, allowing the same markup to render multiple languages while persisting the visitor's preferred choice via `localStorage`.
+- **Content sources** – Language-specific resume data lives in `assets/lang/en.json` and `assets/lang/de.json`, covering metadata, summary text, timeline entries, skills, and more.
+- **Styling** – The published CSS is compiled from the SCSS entry point `assets/scss/shine.scss`, which defines the colour palette, overrides Bootstrap variables, and imports the Shine theme partials.
 
-Shine is a **free Bootstrap 5 resume/CV template** I made for software developers. Built on **Bootstrap 5 and SASS**, it's quick and easy to change the template styling. This modern template is designed to help you **build your personal brand and attract high-paying opportunities**!
+## Project structure
+```
+index.html                # Static shell that loads assets and defines resume sections
+assets/
+  css/shine.css           # Compiled theme stylesheet
+  js/i18n.js              # Language loader and DOM renderer
+  lang/en.json            # English resume content
+  lang/de.json            # German resume content
+  images/                 # Profile photo used in the header
+  scss/                   # Bootstrap + Shine SCSS sources for recompiling the CSS
+favicon.ico               # Browser tab icon
+```
 
-## Author & License
+## Getting started locally
+Because the resume data is fetched with `window.fetch`, the page must be served over HTTP(S). Opening `index.html` directly from the file system will be blocked by most browsers.
 
-This Bootstrap template is made by UX/UI designer [Xiaoying Riley](https://twitter.com/3rdwave_themes) for developers and is 100% FREE as long as you **keep the footer attribution link**. You do not have the rights to resell, sublicense or redistribute (even for free) the template on its own or as a separate attachment from any of your work.
+1. Ensure you have a static file server available (e.g. Python 3).
+2. From the repository root, start a local server:
+   ```bash
+   python3 -m http.server 8000
+   ```
+3. Visit [http://localhost:8000](http://localhost:8000) in your browser to see the site.
 
+Any simple HTTP server (Node's `http-server`, Ruby's `webrick`, etc.) will work equally well.
 
-If you'd like to **use the template without the attribution link**, you can [buy the **commercial license** via the theme website](https://themes.3rdwavemedia.com/bootstrap-templates/resume/shine-free-bootstrap-5-light-mode-resume-cv-template-for-developers/)
+## Updating resume content
+1. Choose the language file you want to edit in `assets/lang/`.
+2. Update the relevant sections:
+   - `meta`: document title, meta description, and HTML `lang` attribute.
+   - `topBar`, `header`, `summary`, `experience`, `additionalExperience`, `techStack`, `softSkills`, `projects`, `education`, `languages`, `interests`: each section maps directly to the markup defined in `index.html` and is rendered by `i18n.js`.
+3. Save the file and refresh your browser. The changes appear immediately because the content is rendered client-side.
 
+The profile photo displayed in the header lives at `assets/images/patrick-nüser.256x256.jpg`; replace this file to update the image without changing the markup.
 
-#### Follow Xiaoying
+## Adding another language
+1. Duplicate an existing JSON file in `assets/lang/` and translate its values.
+2. Register the new file inside `LANGUAGE_FILES` near the top of `assets/js/i18n.js` and add it to the language selector options in each language JSON so it appears in the dropdown.
+3. Optionally set a new default by updating `currentLanguage` in `i18n.js`.
 
-[Twitter](https://twitter.com/3rdwave_themes)
+The loader caches responses and falls back to English if a fetch fails, so additional languages integrate smoothly.
 
-[Facebook](https://www.facebook.com/3rdwavethemes/)
+## Styling and theming
+- Adjust colour tokens or Bootstrap overrides in `assets/scss/shine.scss`, then recompile the CSS using the Sass CLI:
+  ```bash
+  sass assets/scss/shine.scss assets/css/shine.css --style=compressed
+  ```
+- The SCSS entry point imports a full copy of Bootstrap's source and Shine theme partials, allowing fine-grained customisation while keeping the template look and feel.
 
-[Dribbble](https://dribbble.com/Xiaoying)
+## Deployment
+The site is a static bundle, so you can deploy it to any static host (GitHub Pages, Netlify, Vercel, S3, etc.). Upload the repository contents (or the `index.html` and `assets` directory) and ensure the host serves them over HTTPS for best compatibility with the fetch-based localisation.
 
-[Medium](https://medium.com/@3rdwave_themes)
-
-[Linkedin](https://uk.linkedin.com/in/xiaoying)
-
-
-## Latest Version
-**v1.1** - 2024-09-16
-
-[Changelog](https://themes.3rdwavemedia.com/bootstrap-templates/resume/shine-free-bootstrap-5-light-mode-resume-cv-template-for-developers/?target=changelog)
-
-
-## Features
-
--  Fully Responsive
--  HTML5 + CSS3
--  Built on Bootstrap 5
--  **SCSS** source files included
--  FontAwesome icons
--  Bootstrap icons
--  Compatible with all modern browsers
-
-## Credits
-- [Bootstrap](http://getbootstrap.com/)
-- [FontAwesome](http://fortawesome.github.io/Font-Awesome/)
+## Credits & licensing
+This resume builds on the “Shine” Bootstrap 5 template by Xiaoying Riley / 3rd Wave Media, which requires retaining the attribution link in the footer when used for free distributions.

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -1,0 +1,621 @@
+const LANGUAGE_FILES = {
+  en: 'assets/lang/en.json',
+  de: 'assets/lang/de.json'
+};
+
+const languageCache = new Map();
+let currentLanguage = 'en';
+
+async function getLanguageData(language) {
+  if (!LANGUAGE_FILES[language]) {
+    throw new Error(`Unsupported language: ${language}`);
+  }
+
+  if (languageCache.has(language)) {
+    return languageCache.get(language);
+  }
+
+  const response = await fetch(LANGUAGE_FILES[language]);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${LANGUAGE_FILES[language]}: ${response.status}`);
+  }
+
+  const data = await response.json();
+  languageCache.set(language, data);
+  return data;
+}
+
+function cloneIcon(element) {
+  if (!element) {
+    return null;
+  }
+  return element.cloneNode(true);
+}
+
+function setHeadingText(element, text) {
+  if (!element) {
+    return;
+  }
+  const existingIcon = element.querySelector('i');
+  const icon = cloneIcon(existingIcon);
+  element.innerHTML = '';
+  if (icon) {
+    element.appendChild(icon);
+  }
+  const headingText = typeof text === 'string' ? text : '';
+  element.appendChild(document.createTextNode(headingText));
+}
+
+function renderLanguageSelector(data, language) {
+  const select = document.getElementById('language-select');
+  const label = document.getElementById('language-select-label');
+
+  if (!select) {
+    return;
+  }
+
+  if (label && data?.label) {
+    label.textContent = data.label;
+  }
+
+  select.innerHTML = '';
+  const options = Array.isArray(data?.options) ? data.options : [];
+  options.forEach((option) => {
+    if (!option || !option.value) {
+      return;
+    }
+    if (!LANGUAGE_FILES[option.value]) {
+      return;
+    }
+    const opt = document.createElement('option');
+    opt.value = option.value;
+    opt.textContent = option.label || option.value;
+    select.appendChild(opt);
+  });
+
+  if (!Array.from(select.options).some((opt) => opt.value === language)) {
+    const opt = document.createElement('option');
+    opt.value = language;
+    opt.textContent = language;
+    select.appendChild(opt);
+  }
+
+  select.value = language;
+
+  const ariaLabel = data?.ariaLabel || data?.label;
+  if (ariaLabel) {
+    select.setAttribute('aria-label', ariaLabel);
+  } else {
+    select.removeAttribute('aria-label');
+  }
+}
+
+function renderTopBar(data) {
+  const contactButton = document.getElementById('contact-button');
+  const topBarNote = document.getElementById('top-bar-note');
+
+  if (contactButton) {
+    contactButton.textContent = data?.contactLabel || '';
+    contactButton.href = data?.contactLink || '#';
+  }
+
+  if (topBarNote) {
+    topBarNote.textContent = data?.note || '';
+  }
+}
+
+function renderHeader(data) {
+  const profileImage = document.getElementById('profile-image');
+  if (profileImage) {
+    profileImage.alt = data?.profileImageAlt || '';
+  }
+
+  const nameEl = document.getElementById('resume-name');
+  if (nameEl) {
+    nameEl.textContent = data?.name || '';
+  }
+
+  const roleEl = document.getElementById('resume-role-title');
+  if (roleEl) {
+    roleEl.textContent = data?.role || '';
+  }
+
+  const contactList = document.getElementById('contact-list');
+  if (contactList) {
+    contactList.innerHTML = '';
+    const items = Array.isArray(data?.contact) ? data.contact : [];
+    items.forEach((item) => {
+      const li = document.createElement('li');
+      li.className = item?.className || 'list-inline-item me-md-3 me-lg-5';
+
+      if (item?.icon) {
+        const icon = document.createElement('i');
+        icon.className = `resume-contact-icon ${item.icon} me-2`;
+        li.appendChild(icon);
+      }
+
+      if (item?.href) {
+        const link = document.createElement('a');
+        link.href = item.href;
+        link.textContent = item?.text || '';
+        li.appendChild(link);
+      } else if (item?.text) {
+        li.appendChild(document.createTextNode(item.text));
+      }
+
+      contactList.appendChild(li);
+    });
+  }
+}
+
+function renderSummary(data) {
+  const heading = document.getElementById('summary-heading');
+  setHeadingText(heading, data?.heading || '');
+
+  const body = document.getElementById('summary-body');
+  if (body) {
+    body.innerHTML = '';
+    const paragraphs = Array.isArray(data?.paragraphs) ? data.paragraphs : [];
+    paragraphs.forEach((text) => {
+      const p = document.createElement('p');
+      p.textContent = text;
+      body.appendChild(p);
+    });
+  }
+}
+
+function renderExperience(data) {
+  const heading = document.getElementById('experience-heading');
+  setHeadingText(heading, data?.heading || '');
+
+  const timeline = document.getElementById('experience-timeline');
+  if (!timeline) {
+    return;
+  }
+
+  timeline.innerHTML = '';
+  const items = Array.isArray(data?.items) ? data.items : [];
+  items.forEach((item, index) => {
+    const article = document.createElement('article');
+    article.className = 'resume-timeline-item position-relative';
+    if (index < items.length - 1) {
+      article.classList.add('pb-5');
+    }
+
+    const header = document.createElement('div');
+    header.className = 'resume-timeline-item-header mb-2';
+
+    const meta = document.createElement('div');
+    meta.className = 'resume-position-meta d-flex justify-content-between mb-1';
+
+    const time = document.createElement('div');
+    time.className = 'resume-position-time';
+    time.textContent = item?.time || '';
+    meta.appendChild(time);
+
+    const company = document.createElement('div');
+    company.className = 'resume-company-name';
+    company.textContent = item?.company || '';
+    meta.appendChild(company);
+
+    header.appendChild(meta);
+
+    const title = document.createElement('h3');
+    title.className = 'resume-position-title mb-1';
+    title.textContent = item?.title || '';
+    header.appendChild(title);
+
+    const desc = document.createElement('div');
+    desc.className = 'resume-timeline-item-desc';
+    const list = document.createElement('ul');
+    list.className = 'resume-timeline-list';
+
+    const bullets = Array.isArray(item?.bullets) ? item.bullets : [];
+    bullets.forEach((bullet) => {
+      const li = document.createElement('li');
+      li.textContent = bullet;
+      list.appendChild(li);
+    });
+
+    desc.appendChild(list);
+
+    article.appendChild(header);
+    article.appendChild(desc);
+
+    timeline.appendChild(article);
+  });
+}
+
+function renderAdditionalExperience(data) {
+  const heading = document.getElementById('additional-experience-heading');
+  setHeadingText(heading, data?.heading || '');
+
+  const list = document.getElementById('additional-experience-list');
+  if (!list) {
+    return;
+  }
+
+  list.innerHTML = '';
+  const items = Array.isArray(data?.items) ? data.items : [];
+  items.forEach((item) => {
+    const li = document.createElement('li');
+    if (item?.title) {
+      const strong = document.createElement('strong');
+      strong.textContent = item.title;
+      li.appendChild(strong);
+      if (item?.description) {
+        li.appendChild(document.createTextNode(': '));
+      }
+    }
+    if (item?.description) {
+      li.appendChild(document.createTextNode(item.description));
+    }
+    list.appendChild(li);
+  });
+}
+
+function renderTechStack(data) {
+  const heading = document.getElementById('tech-stack-heading');
+  setHeadingText(heading, data?.heading || '');
+
+  const list = document.getElementById('tech-stack-list');
+  if (!list) {
+    return;
+  }
+
+  list.innerHTML = '';
+  list.classList.remove('mb-0');
+
+  const normalizeBadgeLabel = (item) => {
+    if (typeof item === 'string') {
+      return item.trim();
+    }
+    if (item && typeof item === 'object') {
+      const label = item.label || item.name || item.text;
+      return typeof label === 'string' ? label.trim() : '';
+    }
+    return '';
+  };
+
+  const groups = Array.isArray(data?.groups) ? data.groups.filter((group) => {
+    if (!group || typeof group !== 'object') {
+      return false;
+    }
+    const hasTitle = typeof group.title === 'string' && group.title.trim() !== '';
+    const items = Array.isArray(group.items) ? group.items : [];
+    const hasItems = items.some((item) => normalizeBadgeLabel(item));
+    return hasTitle || hasItems;
+  }) : [];
+
+  if (groups.length > 0) {
+    list.classList.add('mb-0');
+    let renderedGroups = false;
+
+    groups.forEach((group, index) => {
+      const li = document.createElement('li');
+      if (index < groups.length - 1) {
+        li.classList.add('mb-4');
+      }
+
+      let hasContent = false;
+
+      if (typeof group.title === 'string' && group.title.trim() !== '') {
+        const title = document.createElement('div');
+        title.className = 'resume-skill-name text-uppercase text-secondary fs-6 fw-bold mb-2';
+        title.textContent = group.title;
+        li.appendChild(title);
+        hasContent = true;
+      }
+
+      const badges = Array.isArray(group.items) ? group.items : [];
+      const inlineList = document.createElement('ul');
+      inlineList.className = 'list-inline';
+      let hasBadges = false;
+
+      badges.forEach((badge) => {
+        const label = normalizeBadgeLabel(badge);
+        if (!label) {
+          return;
+        }
+        const badgeItem = document.createElement('li');
+        badgeItem.className = 'list-inline-item';
+        const badgeSpan = document.createElement('span');
+        badgeSpan.className = 'badge resume-skill-badge';
+        badgeSpan.textContent = label;
+        badgeItem.appendChild(badgeSpan);
+        inlineList.appendChild(badgeItem);
+        hasBadges = true;
+      });
+
+      if (hasBadges) {
+        li.appendChild(inlineList);
+        hasContent = true;
+      }
+
+      if (hasContent) {
+        list.appendChild(li);
+        renderedGroups = true;
+      }
+    });
+
+    if (renderedGroups) {
+      return;
+    }
+
+    list.classList.remove('mb-0');
+  }
+
+  const items = Array.isArray(data?.items) ? data.items : [];
+  items.forEach((item) => {
+    const li = document.createElement('li');
+    li.className = 'mb-2';
+
+    const name = document.createElement('div');
+    name.className = 'resume-skill-name';
+    name.textContent = item?.name || '';
+    li.appendChild(name);
+
+    const progress = document.createElement('div');
+    progress.className = 'progress resume-progress';
+    progress.setAttribute('role', 'progressbar');
+    progress.setAttribute('aria-valuemin', '0');
+    progress.setAttribute('aria-valuemax', '100');
+    progress.setAttribute('aria-valuenow', String(item?.value ?? 0));
+    if (data?.progressAriaLabel) {
+      progress.setAttribute('aria-label', data.progressAriaLabel);
+    }
+
+    const bar = document.createElement('div');
+    bar.className = 'progress-bar resume-progress-bar';
+    const width = Math.max(0, Math.min(100, Number(item?.value ?? 0)));
+    bar.style.width = `${width}%`;
+
+    progress.appendChild(bar);
+    li.appendChild(progress);
+
+    list.appendChild(li);
+  });
+}
+
+function renderSoftSkills(data) {
+  const heading = document.getElementById('soft-skills-heading');
+  setHeadingText(heading, data?.heading || '');
+
+  const list = document.getElementById('soft-skills-list');
+  if (!list) {
+    return;
+  }
+
+  list.innerHTML = '';
+  const items = Array.isArray(data?.items) ? data.items : [];
+  items.forEach((skill) => {
+    const li = document.createElement('li');
+    li.className = 'list-inline-item';
+
+    const badge = document.createElement('span');
+    badge.className = 'badge resume-skill-badge';
+    badge.textContent = skill;
+
+    li.appendChild(badge);
+    list.appendChild(li);
+  });
+}
+
+function renderProjects(data) {
+  const heading = document.getElementById('projects-heading');
+  setHeadingText(heading, data?.heading || '');
+
+  const container = document.getElementById('projects-list');
+  if (!container) {
+    return;
+  }
+
+  container.innerHTML = '';
+  const items = Array.isArray(data?.items) ? data.items : [];
+  items.forEach((item) => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'item';
+
+    const title = document.createElement('h4');
+    title.className = 'item-heading';
+    const icon = document.createElement('i');
+    icon.className = 'item-icon bi bi-square-fill me-2';
+    title.appendChild(icon);
+    title.appendChild(document.createTextNode(item?.name || ''));
+
+    const desc = document.createElement('div');
+    desc.className = 'item-desc';
+    desc.textContent = item?.description || '';
+
+    wrapper.appendChild(title);
+    wrapper.appendChild(desc);
+    container.appendChild(wrapper);
+  });
+}
+
+function renderEducation(data) {
+  const heading = document.getElementById('education-heading');
+  setHeadingText(heading, data?.heading || '');
+
+  const list = document.getElementById('education-list');
+  if (!list) {
+    return;
+  }
+
+  list.innerHTML = '';
+  const items = Array.isArray(data?.items) ? data.items : [];
+  items.forEach((item, index) => {
+    const li = document.createElement('li');
+    if (index < items.length - 1) {
+      li.classList.add('mb-2');
+    }
+
+    const degree = document.createElement('div');
+    degree.className = 'resume-degree font-weight-bold';
+    degree.textContent = item?.degree || '';
+    li.appendChild(degree);
+
+    const org = document.createElement('div');
+    org.className = 'resume-degree-org';
+    org.textContent = item?.organisation || '';
+    li.appendChild(org);
+
+    const time = document.createElement('div');
+    time.className = 'resume-degree-time';
+    time.textContent = item?.time || '';
+    li.appendChild(time);
+
+    const desc = document.createElement('div');
+    desc.className = 'resume-degree-desc';
+    desc.textContent = item?.description || '';
+    li.appendChild(desc);
+
+    list.appendChild(li);
+  });
+}
+
+function renderLanguages(data) {
+  const heading = document.getElementById('languages-heading');
+  setHeadingText(heading, data?.heading || '');
+
+  const list = document.getElementById('languages-list');
+  if (!list) {
+    return;
+  }
+
+  list.innerHTML = '';
+  const maxLevel = Number.isFinite(data?.maxLevel) ? Number(data.maxLevel) : 10;
+  const items = Array.isArray(data?.items) ? data.items : [];
+
+  items.forEach((item, index) => {
+    const li = document.createElement('li');
+    if (index < items.length - 1) {
+      li.classList.add('mb-2');
+    }
+
+    const name = document.createElement('div');
+    name.className = 'resume-lang-name';
+    name.textContent = item?.name || '';
+    li.appendChild(name);
+
+    const indicator = document.createElement('div');
+    indicator.className = 'resume-level-indicator row gx-0 flex-nowrap';
+
+    const levelValue = Number(item?.level ?? 0);
+    const fullSegments = Math.floor(levelValue);
+    const hasHalf = levelValue - fullSegments >= 0.5;
+
+    for (let i = 0; i < maxLevel; i += 1) {
+      const col = document.createElement('div');
+      col.className = 'col';
+      const span = document.createElement('span');
+      span.className = 'item';
+      if (i < fullSegments) {
+        span.classList.add('item-full');
+      } else if (i === fullSegments && hasHalf) {
+        span.classList.add('item-half');
+      }
+      col.appendChild(span);
+      indicator.appendChild(col);
+    }
+
+    li.appendChild(indicator);
+    list.appendChild(li);
+  });
+}
+
+function renderInterests(data) {
+  const heading = document.getElementById('interests-heading');
+  setHeadingText(heading, data?.heading || '');
+
+  const list = document.getElementById('interests-list');
+  if (!list) {
+    return;
+  }
+
+  list.innerHTML = '';
+  const items = Array.isArray(data?.items) ? data.items : [];
+  items.forEach((interest) => {
+    const li = document.createElement('li');
+    li.className = 'list-inline-item';
+
+    const badge = document.createElement('span');
+    badge.className = 'badge resume-skill-badge';
+    badge.textContent = interest;
+
+    li.appendChild(badge);
+    list.appendChild(li);
+  });
+}
+
+function applyTranslations(data, language) {
+  if (data?.meta) {
+    document.documentElement.lang = data.meta.lang || language;
+    if (typeof data.meta.title === 'string') {
+      document.title = data.meta.title;
+    }
+    const descriptionMeta = document.querySelector('meta[name="description"]');
+    if (descriptionMeta && typeof data.meta.description === 'string') {
+      descriptionMeta.setAttribute('content', data.meta.description);
+    }
+  }
+
+  renderLanguageSelector(data?.languageSelector, language);
+  renderTopBar(data?.topBar);
+  renderHeader(data?.header);
+  renderSummary(data?.summary);
+  renderExperience(data?.experience);
+  renderAdditionalExperience(data?.additionalExperience);
+  renderTechStack(data?.techStack);
+  renderSoftSkills(data?.softSkills);
+  renderProjects(data?.projects);
+  renderEducation(data?.education);
+  renderLanguages(data?.languages);
+  renderInterests(data?.interests);
+}
+
+async function loadLanguage(language) {
+  let targetLanguage = LANGUAGE_FILES[language] ? language : 'en';
+  try {
+    const data = await getLanguageData(targetLanguage);
+    applyTranslations(data, targetLanguage);
+    currentLanguage = targetLanguage;
+    return targetLanguage;
+  } catch (error) {
+    console.error(`Failed to load language "${language}":`, error);
+    if (targetLanguage !== 'en') {
+      try {
+        const fallbackData = await getLanguageData('en');
+        applyTranslations(fallbackData, 'en');
+        currentLanguage = 'en';
+        return 'en';
+      } catch (fallbackError) {
+        console.error('Failed to load fallback language "en":', fallbackError);
+      }
+    }
+  }
+  return currentLanguage;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const select = document.getElementById('language-select');
+  const storedLanguage = localStorage.getItem('preferredLanguage');
+  const initialLanguage = storedLanguage && LANGUAGE_FILES[storedLanguage] ? storedLanguage : 'en';
+
+  if (select) {
+    select.addEventListener('change', (event) => {
+      const chosenLanguage = event.target.value;
+      loadLanguage(chosenLanguage).then((loadedLanguage) => {
+        if (loadedLanguage && LANGUAGE_FILES[loadedLanguage]) {
+          localStorage.setItem('preferredLanguage', loadedLanguage);
+        }
+      });
+    });
+  }
+
+  loadLanguage(initialLanguage).then((loadedLanguage) => {
+    if (loadedLanguage && LANGUAGE_FILES[loadedLanguage]) {
+      localStorage.setItem('preferredLanguage', loadedLanguage);
+    }
+  });
+});

--- a/assets/lang/de.json
+++ b/assets/lang/de.json
@@ -1,0 +1,261 @@
+{
+  "meta": {
+    "lang": "de",
+    "title": "Patrick Nüser – Senior Software Engineer",
+    "description": "Lebenslauf von Patrick Nüser, Senior Software Engineer aus Hamburg."
+  },
+  "languageSelector": {
+    "label": "Sprache",
+    "ariaLabel": "Sprache auswählen",
+    "options": [
+      { "value": "en", "label": "Englisch" },
+      { "value": "de", "label": "Deutsch" }
+    ]
+  },
+  "topBar": {
+    "contactLabel": "Kontakt",
+    "contactLink": "mailto:mail@patrick-nueser.de",
+    "note": "Senior Software Engineer · Team-/Tech-Lead · Cloud & AI Solutions"
+  },
+  "header": {
+    "name": "Patrick Nüser",
+    "role": "Senior Software Engineer · Team-/Tech-Lead · Cloud & AI Solutions",
+    "profileImageAlt": "Porträt von Patrick Nüser",
+    "contact": [
+      {
+        "icon": "bi bi-telephone-inbound",
+        "href": "tel:+4917662196684",
+        "text": "+49 176 62196684",
+        "className": "list-inline-item me-md-3 me-lg-5"
+      },
+      {
+        "icon": "bi bi-envelope",
+        "href": "mailto:mail@patrick-nueser.de",
+        "text": "mail@patrick-nueser.de",
+        "className": "list-inline-item me-md-3 me-lg-5"
+      },
+      {
+        "icon": "bi bi-geo-alt",
+        "text": "Hamburg, Deutschland",
+        "className": "list-inline-item me-lg-5"
+      }
+    ]
+  },
+  "summary": {
+    "heading": "Profil",
+    "paragraphs": [
+      "Ich bin Patrick, ein Software Engineer aus Hamburg. Komplexe Probleme motivieren mich, spannende Projekte treiben mich an. Dank meiner analytischen Denkweise erkenne und löse ich Herausforderungen schnell und strukturiert. Besonders im Team kommen meine kommunikativen Fähigkeiten zur Geltung – ich arbeite konstruktiv, lösungsorientiert und mit einem klaren Blick für Kosten und Nutzen.",
+      "Durch meinen sportlichen Hintergrund habe ich Disziplin und Resilienz gelernt: dranzubleiben, wenn es hart wird, und Gelassenheit zu bewahren, wenn es die Situation erlaubt. Neue Technologien begeistern mich – ich entwickle mich fachlich wie persönlich stetig weiter."
+    ]
+  },
+  "experience": {
+    "heading": "Berufserfahrung",
+    "items": [
+      {
+        "time": "09/2024 – heute",
+        "company": "1Komma5° Heartbeat GmbH · Hamburg",
+        "title": "Senior Softwareentwickler",
+        "bullets": [
+          "Lead-Qualifizierungs-Service: Technische Projektleitung & Systemdesign → ~10 Min. Zeitersparnis pro Lead, validierte/standardisierte Datenerfassung für Reporting & Downstream-Systeme.",
+          "Architektur: ADR für Workflow Engines konzipiert → Standardisierung & Skalierbarkeit von CRM-Integrationen.",
+          "Mentoring: Regelmäßige Pairing-Sessions; Vermittlung von Patterns & Principles → Skill-Aufbau im Team.",
+          "AI/LLM: Mitgestaltung der LLM-Arbeitsgruppe → Standards für LLM-gestützte Entwicklung etabliert."
+        ]
+      },
+      {
+        "time": "03/2022 – 07/2024",
+        "company": "Njiuko GmbH · Hamburg",
+        "title": "Softwareentwickler, Team-/Tech-Lead",
+        "bullets": [
+          "Führung: Leitung von 8 Engineers (fachlich & disziplinarisch: Gehaltsgespräche, Entwicklungspläne, OKRs, Recruiting, Offboarding).",
+          "Effizienz: Standardisierung der HubSpot-Entwicklung via Workflow Engines → Integrationsprojekte bis zu 50 % schneller.",
+          "Tech-Transformation: Stack-Wandel von Ruby on Rails zu TypeScript aktiv mitgestaltet.",
+          "Talententwicklung: Umschulung von Mobile- zu Web-Entwicklern → bessere Auslastung & Skill-Diversität.",
+          "Business Impact: Große Aufträge gewonnen/gesichert (u. a. Gruner & Jahr, Ysolutions); Budgetverantwortung, Angebote, technische Evaluationen."
+        ]
+      },
+      {
+        "time": "01/2019 – 03/2022",
+        "company": "tourrise GmbH · Hamburg",
+        "title": "Technischer Mitgründer (CTO)",
+        "bullets": [
+          "Produktaufbau: Architektur & Umsetzung der initialen Infrastruktur (Mandantenfähigkeit, Payment, Front-/Mid-/Backoffice).",
+          "Integrationen: Schnittstellen zu Flugdienstleistern, Rechnungsstellung, Buchhaltung.",
+          "Impact: 2 zahlende Kunden (~200 k ARR) → Produkt im Markt etabliert.",
+          "Tech: Ruby on Rails, Docker, Kamal."
+        ]
+      },
+      {
+        "time": "03/2017 – 07/2022",
+        "company": "Selbstständig · Remote/Hamburg",
+        "title": "Full-Stack Entwickler & Berater",
+        "bullets": [
+          "OMR: Reviews-Produkt mitgeplant; Kerninfrastruktur implementiert.",
+          "Peek & Cloppenburg: Corporate-Sites modernisiert → Next.js + Headless CMS.",
+          "XING: GDPR-Infrastruktur im „Startpage“-Team mitkonzipiert & entwickelt.",
+          "A.W. Niemeyer: Shopify-Umzug, Liquid Templates & Custom Apps; ERP-Modernisierung für Echtzeit-Verfügbarkeiten.",
+          "Weitere Projekte: Technische Architektur/Planung & strategische Beratung (KMU/Enterprise)."
+        ]
+      },
+      {
+        "time": "06/2014 – 03/2017",
+        "company": "Njiuko GmbH · Hamburg",
+        "title": "Backend Entwickler",
+        "bullets": [
+          "Entwicklung neuer und bestehender Plattformen (Protonet SOUL, Lagardère Sports Keeper, Protonet Leads App).",
+          "DevOps & Betrieb hochverfügbarer Systeme; Code Reviews & Pair Programming."
+        ]
+      }
+    ]
+  },
+  "additionalExperience": {
+    "heading": "Weitere Erfahrungen (Auswahl)",
+    "items": [
+      {
+        "title": "Selbstständig (2012–2014)",
+        "description": "Buchungssystem (Kontingente, Rollen, REST, Easybill-/Flightstats); Radsportkarte Fuerteventura (mit Hannes Hawaii Tours, Adobe Suite)."
+      },
+      {
+        "title": "Hannes Hawaii Tours (2009–2014)",
+        "description": "Tourguide & Reiseleiter, Gruppen bis 120 Personen, Teamkoordination."
+      },
+      {
+        "title": "Jack Wolfskin (2010–2012)",
+        "description": "Verkauf von Funktionstextilien & Zubehör."
+      },
+      {
+        "title": "SCOL Skireisen (2006–2008)",
+        "description": "Leitung von Jugend- & Familiengruppen (Saison)."
+      },
+      {
+        "title": "Sport Reckemeier (2006–2008)",
+        "description": "Laufschuhfachverkäufer; Vertretung Geschäftsführung, Jahresorder."
+      },
+      {
+        "title": "Etzhorner Krug (2004–2006)",
+        "description": "Tellerwäscher (erster Job)."
+      },
+      {
+        "title": "Zivildienst (08/2007 – 06/2008)",
+        "description": "Landesbildungszentrum für Hörgeschädigte, Oldenburg."
+      }
+    ]
+  },
+  "techStack": {
+    "heading": "Tech Stack",
+    "groups": [
+      {
+        "title": "Backend & Plattformen",
+        "items": [
+          "Ruby",
+          "Ruby on Rails",
+          "TypeScript",
+          "Node.js",
+          "NestJS",
+          "REST APIs"
+        ]
+      },
+      {
+        "title": "Frontend & Commerce",
+        "items": [
+          "React",
+          "Next.js",
+          "Vue.js",
+          "Nuxt",
+          "Headless CMS",
+          "Shopify",
+          "Liquid Templates"
+        ]
+      },
+      {
+        "title": "Cloud & DevOps",
+        "items": [
+          "AWS",
+          "Azure",
+          "Google Cloud",
+          "Docker",
+          "Kamal"
+        ]
+      },
+      {
+        "title": "Daten, AI & Integrationen",
+        "items": [
+          "PostgreSQL",
+          "MySQL",
+          "Redis",
+          "Elasticsearch",
+          "HubSpot",
+          "Workflow Engines",
+          "ERP-Integrationen",
+          "Payment & Billing APIs",
+          "LLM-gestützte Entwicklung"
+        ]
+      }
+    ]
+  },
+  "softSkills": {
+    "heading": "Soft Skills",
+    "items": [
+      "Teamführung & Coaching",
+      "Architektur & Systemdesign",
+      "Stakeholder-Management",
+      "Produktfokus & Kosten-Nutzen",
+      "Mentoring & Pairing",
+      "Code-Quality & Reviews"
+    ]
+  },
+  "projects": {
+    "heading": "Projekte (Auswahl)",
+    "items": [
+      {
+        "name": "OMR – Reviews",
+        "description": "Reviews-Produkt mitgeplant und Kernkomponenten der skalierbaren Architektur implementiert."
+      },
+      {
+        "name": "Peek & Cloppenburg – Corporate Sites",
+        "description": "Corporate-Websites modernisiert: Next.js + Headless CMS für bessere Performance & effizientere Workflows."
+      },
+      {
+        "name": "XING – GDPR-Infrastruktur",
+        "description": "Compliance-fähige Systeme im „Startpage“-Team mitkonzipiert und entwickelt, Fokus auf Stabilität & Wartbarkeit."
+      },
+      {
+        "name": "A.W. Niemeyer – Shopify & ERP",
+        "description": "Shopify-Migration inkl. Custom Apps; ERP-Modernisierung für Echtzeit-Verfügbarkeiten im Handel."
+      }
+    ]
+  },
+  "education": {
+    "heading": "Ausbildung",
+    "items": [
+      {
+        "degree": "B.Sc. Informatik",
+        "organisation": "Universität Osnabrück",
+        "time": "Abschluss 12/2013",
+        "description": "Abschlussarbeit: Entwicklung einer Livestreaming- & VOD-Komponente für ein Online-Rückenstudio. Tutorien: Software Engineering (04–07/2013); Gleichungsbasierte Modelle I (04–07/2012)."
+      },
+      {
+        "degree": "Auslandssemester Informatik",
+        "organisation": "Universität Stockholm",
+        "time": "08/2012 – 02/2013",
+        "description": "Schwerpunkte: Data Mining, Network Security, Computer Security."
+      }
+    ]
+  },
+  "languages": {
+    "heading": "Sprachen",
+    "maxLevel": 10,
+    "items": [
+      { "name": "Deutsch (Muttersprache)", "level": 10 },
+      { "name": "Englisch (fließend)", "level": 9.5 }
+    ]
+  },
+  "interests": {
+    "heading": "Interessen",
+    "items": [
+      "Langjähriger Leistungssport (Triathlon, Laufen, Rennrad)",
+      "Kochen & Essen",
+      "Tech & Games"
+    ]
+  }
+}

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -1,0 +1,261 @@
+{
+  "meta": {
+    "lang": "en",
+    "title": "Patrick Nüser – Senior Software Engineer",
+    "description": "Resume of Patrick Nüser, Senior Software Engineer from Hamburg."
+  },
+  "languageSelector": {
+    "label": "Language",
+    "ariaLabel": "Select language",
+    "options": [
+      { "value": "en", "label": "English" },
+      { "value": "de", "label": "German" }
+    ]
+  },
+  "topBar": {
+    "contactLabel": "Contact",
+    "contactLink": "mailto:mail@patrick-nueser.de",
+    "note": "Senior Software Engineer · Team/Tech Lead · Cloud & AI Solutions"
+  },
+  "header": {
+    "name": "Patrick Nüser",
+    "role": "Senior Software Engineer · Team/Tech Lead · Cloud & AI Solutions",
+    "profileImageAlt": "Portrait of Patrick Nüser",
+    "contact": [
+      {
+        "icon": "bi bi-telephone-inbound",
+        "href": "tel:+4917662196684",
+        "text": "+49 176 62196684",
+        "className": "list-inline-item me-md-3 me-lg-5"
+      },
+      {
+        "icon": "bi bi-envelope",
+        "href": "mailto:mail@patrick-nueser.de",
+        "text": "mail@patrick-nueser.de",
+        "className": "list-inline-item me-md-3 me-lg-5"
+      },
+      {
+        "icon": "bi bi-geo-alt",
+        "text": "Hamburg, Germany",
+        "className": "list-inline-item me-lg-5"
+      }
+    ]
+  },
+  "summary": {
+    "heading": "Profile",
+    "paragraphs": [
+      "I'm Patrick, a software engineer from Hamburg. Complex problems motivate me, exciting projects drive me. Thanks to my analytical mindset I recognize and solve challenges quickly and in a structured way. Especially in teams my communication skills shine – I work constructively, solution-oriented and with a clear view of cost and benefit.",
+      "My sports background taught me discipline and resilience: sticking with it when things get tough and staying calm when the situation allows. New technologies excite me – I continuously develop both professionally and personally."
+    ]
+  },
+  "experience": {
+    "heading": "Professional Experience",
+    "items": [
+      {
+        "time": "09/2024 – present",
+        "company": "1Komma5° Heartbeat GmbH · Hamburg",
+        "title": "Senior Software Engineer",
+        "bullets": [
+          "Lead qualification service: technical project leadership & system design → ~10 minutes saved per lead, validated/standardized data capture for reporting & downstream systems.",
+          "Architecture: designed ADRs for workflow engines → standardized & scalable CRM integrations.",
+          "Mentoring: regular pairing sessions; sharing patterns & principles → capability building within the team.",
+          "AI/LLM: co-shaped the LLM working group → established standards for LLM-assisted development."
+        ]
+      },
+      {
+        "time": "03/2022 – 07/2024",
+        "company": "Njiuko GmbH · Hamburg",
+        "title": "Software Engineer, Team/Tech Lead",
+        "bullets": [
+          "Leadership: managed 8 engineers (disciplinary & functional: salary reviews, development plans, OKRs, recruiting, offboarding).",
+          "Efficiency: standardized HubSpot development via workflow engines → integration projects up to 50% faster.",
+          "Tech transformation: actively shaped the shift from Ruby on Rails to TypeScript.",
+          "Talent development: retrained mobile engineers to web → higher utilization & skill diversity.",
+          "Business impact: won/retained major accounts (incl. Gruner & Jahr, Ysolutions); budget ownership, proposals, technical evaluations."
+        ]
+      },
+      {
+        "time": "01/2019 – 03/2022",
+        "company": "tourrise GmbH · Hamburg",
+        "title": "Technical Co-Founder (CTO)",
+        "bullets": [
+          "Product build: architecture & implementation of the initial infrastructure (multi-tenancy, payments, front-/mid-/back office).",
+          "Integrations: interfaces to flight providers, invoicing, accounting.",
+          "Impact: 2 paying customers (~€200k ARR) → established product in the market.",
+          "Tech: Ruby on Rails, Docker, Kamal."
+        ]
+      },
+      {
+        "time": "03/2017 – 07/2022",
+        "company": "Self-employed · Remote/Hamburg",
+        "title": "Full-Stack Engineer & Consultant",
+        "bullets": [
+          "OMR: co-planned the reviews product; implemented core infrastructure.",
+          "Peek & Cloppenburg: modernized corporate sites → Next.js + headless CMS.",
+          "XING: co-designed & built GDPR infrastructure in the Startpage team.",
+          "A.W. Niemeyer: Shopify migration, Liquid templates & custom apps; modernized ERP for real-time availability.",
+          "Other projects: technical architecture/planning & strategic consulting (SMB/enterprise)."
+        ]
+      },
+      {
+        "time": "06/2014 – 03/2017",
+        "company": "Njiuko GmbH · Hamburg",
+        "title": "Backend Engineer",
+        "bullets": [
+          "Built new & existing platforms (Protonet SOUL, Lagardère Sports Keeper, Protonet Leads App).",
+          "DevOps & operations for highly available systems; code reviews & pair programming."
+        ]
+      }
+    ]
+  },
+  "additionalExperience": {
+    "heading": "Additional experience (selected)",
+    "items": [
+      {
+        "title": "Freelance (2012–2014)",
+        "description": "Booking system (inventory, roles, REST, Easybill/Flightstats); road cycling map Fuerteventura (with Hannes Hawaii Tours, Adobe Suite)."
+      },
+      {
+        "title": "Hannes Hawaii Tours (2009–2014)",
+        "description": "Tour guide & travel lead, groups up to 120 people, team coordination."
+      },
+      {
+        "title": "Jack Wolfskin (2010–2012)",
+        "description": "Sold functional textiles & accessories."
+      },
+      {
+        "title": "SCOL Ski Trips (2006–2008)",
+        "description": "Led youth & family groups (seasonal)."
+      },
+      {
+        "title": "Sport Reckemeier (2006–2008)",
+        "description": "Specialist running shoe sales; deputized store management, annual ordering."
+      },
+      {
+        "title": "Etzhorner Krug (2004–2006)",
+        "description": "Dishwasher (first job)."
+      },
+      {
+        "title": "Civil service (08/2007 – 06/2008)",
+        "description": "State Education Center for the Hearing Impaired, Oldenburg."
+      }
+    ]
+  },
+  "techStack": {
+    "heading": "Tech Stack",
+    "groups": [
+      {
+        "title": "Backend & Platforms",
+        "items": [
+          "Ruby",
+          "Ruby on Rails",
+          "TypeScript",
+          "Node.js",
+          "NestJS",
+          "REST APIs"
+        ]
+      },
+      {
+        "title": "Frontend & Commerce",
+        "items": [
+          "React",
+          "Next.js",
+          "Vue.js",
+          "Nuxt",
+          "Headless CMS",
+          "Shopify",
+          "Liquid Templates"
+        ]
+      },
+      {
+        "title": "Cloud & DevOps",
+        "items": [
+          "AWS",
+          "Azure",
+          "Google Cloud",
+          "Docker",
+          "Kamal"
+        ]
+      },
+      {
+        "title": "Data, AI & Integrations",
+        "items": [
+          "PostgreSQL",
+          "MySQL",
+          "Redis",
+          "Elasticsearch",
+          "HubSpot",
+          "Workflow engines",
+          "ERP integrations",
+          "Payment & billing APIs",
+          "LLM-assisted development"
+        ]
+      }
+    ]
+  },
+  "softSkills": {
+    "heading": "Soft Skills",
+    "items": [
+      "Team leadership & coaching",
+      "Architecture & system design",
+      "Stakeholder management",
+      "Product focus & cost-benefit",
+      "Mentoring & pairing",
+      "Code quality & reviews"
+    ]
+  },
+  "projects": {
+    "heading": "Projects (selected)",
+    "items": [
+      {
+        "name": "OMR – Reviews",
+        "description": "Co-planned the reviews product and implemented core components of the scalable architecture."
+      },
+      {
+        "name": "Peek & Cloppenburg – Corporate Sites",
+        "description": "Modernized corporate websites: Next.js + headless CMS for better performance & more efficient workflows."
+      },
+      {
+        "name": "XING – GDPR Infrastructure",
+        "description": "Co-designed and built compliance-ready systems in the Startpage team with focus on stability & maintainability."
+      },
+      {
+        "name": "A.W. Niemeyer – Shopify & ERP",
+        "description": "Shopify migration including custom apps; modernized ERP for real-time availability in retail."
+      }
+    ]
+  },
+  "education": {
+    "heading": "Education",
+    "items": [
+      {
+        "degree": "B.Sc. Computer Science",
+        "organisation": "University of Osnabrück",
+        "time": "Graduated 12/2013",
+        "description": "Thesis: Developed a live streaming & VOD component for an online back training studio. Tutorials: Software Engineering (04–07/2013); Equation-based Models I (04–07/2012)."
+      },
+      {
+        "degree": "Study abroad – Computer Science",
+        "organisation": "University of Stockholm",
+        "time": "08/2012 – 02/2013",
+        "description": "Focus areas: data mining, network security, computer security."
+      }
+    ]
+  },
+  "languages": {
+    "heading": "Languages",
+    "maxLevel": 10,
+    "items": [
+      { "name": "German (native)", "level": 10 },
+      { "name": "English (fluent)", "level": 9.5 }
+    ]
+  },
+  "interests": {
+    "heading": "Interests",
+    "items": [
+      "Competitive endurance sports (triathlon, running, road cycling)",
+      "Cooking & food",
+      "Tech & games"
+    ]
+  }
+}

--- a/index.html
+++ b/index.html
@@ -212,45 +212,52 @@
                                                                         <section class="resume-skills-section resume-section">
                                                                                 <h3 class="resume-section-heading text-uppercase py-2 py-lg-3 py-3"><i class="resume-section-heading-icon bi bi-gear me-2"></i>Tech Stack</h3>
 
-                                                                                <ul class="list-unstyled">
-                                                                        <li class="mb-2">
-                                                                            <div class="resume-skill-name">Ruby &amp; Rails</div>
-                                                                                        <div class="progress resume-progress" role="progressbar" aria-label="Kenntnisstand" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100">
-                                                                                          <div class="progress-bar resume-progress-bar" style="width: 95%"></div>
-                                                                                        </div>
-                                                                        </li>
-                                                                        <li class="mb-2">
-                                                                            <div class="resume-skill-name">TypeScript, Node.js &amp; NestJS</div>
-                                                                            <div class="progress resume-progress" role="progressbar" aria-label="Kenntnisstand" aria-valuenow="92" aria-valuemin="0" aria-valuemax="100">
-                                                                                          <div class="progress-bar resume-progress-bar" style="width: 92%"></div>
-                                                                                        </div>
-
-                                                                        </li>
-                                                                        <li class="mb-2">
-                                                                            <div class="resume-skill-name">React, Next.js, Vue &amp; Nuxt</div>
-                                                                                <div class="progress resume-progress" role="progressbar" aria-label="Kenntnisstand" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100">
-                                                                                          <div class="progress-bar resume-progress-bar" style="width: 90%"></div>
-                                                                                        </div>
-                                                                        </li>
-                                                                        <li class="mb-2">
-                                                                            <div class="resume-skill-name">Cloud (AWS, Azure, GCP) &amp; DevOps</div>
-                                                                                <div class="progress resume-progress" role="progressbar" aria-label="Kenntnisstand" aria-valuenow="88" aria-valuemin="0" aria-valuemax="100">
-                                                                                          <div class="progress-bar resume-progress-bar" style="width: 88%"></div>
-                                                                                        </div>
-                                                                        </li>
-                                                                        <li class="mb-2">
-                                                                            <div class="resume-skill-name">Datenbanken &amp; Suche (Postgres, MySQL, Redis, Elasticsearch)</div>
-                                                                                <div class="progress resume-progress" role="progressbar" aria-label="Kenntnisstand" aria-valuenow="86" aria-valuemin="0" aria-valuemax="100">
-                                                                                          <div class="progress-bar resume-progress-bar" style="width: 86%"></div>
-                                                                                        </div>
-                                                                        </li>
-                                                                        <li class="mb-2">
-                                                                            <div class="resume-skill-name">AI/LLM-gestützte Entwicklung</div>
-                                                                                <div class="progress resume-progress" role="progressbar" aria-label="Kenntnisstand" aria-valuenow="82" aria-valuemin="0" aria-valuemax="100">
-                                                                                          <div class="progress-bar resume-progress-bar" style="width: 82%"></div>
-                                                                                        </div>
-                                                                        </li>
-                                                                </ul>
+                                                                                <div class="mb-4">
+                                                                                        <h4 class="text-uppercase text-secondary fs-6 fw-bold mb-2">Backend &amp; Plattformen</h4>
+                                                                                        <ul class="list-inline">
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Ruby</span></li>
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Ruby on Rails</span></li>
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">TypeScript</span></li>
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Node.js</span></li>
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">NestJS</span></li>
+                                                                                        </ul>
+                                                                                </div>
+                                                                                <div class="mb-4">
+                                                                                        <h4 class="text-uppercase text-secondary fs-6 fw-bold mb-2">Frontend &amp; Commerce</h4>
+                                                                                        <ul class="list-inline">
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">React</span></li>
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Next.js</span></li>
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Vue.js</span></li>
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Nuxt</span></li>
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Headless CMS</span></li>
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Shopify</span></li>
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Liquid Templates</span></li>
+                                                                                        </ul>
+                                                                                </div>
+                                                                                <div class="mb-4">
+                                                                                        <h4 class="text-uppercase text-secondary fs-6 fw-bold mb-2">Cloud &amp; DevOps</h4>
+                                                                                        <ul class="list-inline">
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">AWS</span></li>
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Azure</span></li>
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Google Cloud</span></li>
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Docker</span></li>
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Kamal</span></li>
+                                                                                        </ul>
+                                                                                </div>
+                                                                                <div>
+                                                                                        <h4 class="text-uppercase text-secondary fs-6 fw-bold mb-2">Daten, AI &amp; Integrationen</h4>
+                                                                                        <ul class="list-inline">
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">PostgreSQL</span></li>
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">MySQL</span></li>
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Redis</span></li>
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Elasticsearch</span></li>
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">HubSpot</span></li>
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Workflow Engines</span></li>
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">ERP-Integrationen</span></li>
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Payment &amp; Billing APIs</span></li>
+                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">LLM-gestützte Entwicklung</span></li>
+                                                                                        </ul>
+                                                                                </div>
 
                                                                         </section><!--//resume-section-->
 

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
                                                         <div class="row">
                                                                 <div class="col-main col-12 col-lg-8 pe-lg-4">
                                                                         <section class="resume-summary-section resume-section">
-                                                                                <h3 class="resume-section-heading text-uppercase py-2 py-lg-3 py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-person me-2"></i>Profil</h3>
+                                                                                <h3 class="resume-section-heading text-uppercase py-2 py-lg-3 py-3"><i class="resume-section-heading-icon bi bi-person me-2"></i>Profil</h3>
                                                                                 <div class="resume-summary-desc">
                                                                                         <p>Ich bin Patrick, ein Software Engineer aus Hamburg. Komplexe Probleme motivieren mich, spannende Projekte treiben mich an. Dank meiner analytischen Denkweise erkenne und löse ich Herausforderungen schnell und strukturiert. Besonders im Team kommen meine kommunikativen Fähigkeiten zur Geltung – ich arbeite konstruktiv, lösungsorientiert und mit einem klaren Blick für Kosten und Nutzen.</p>
                                                                                         <p>Durch meinen sportlichen Hintergrund habe ich Disziplin und Resilienz gelernt: dranzubleiben, wenn es hart wird, und Gelassenheit zu bewahren, wenn es die Situation erlaubt. Neue Technologien begeistern mich – ich entwickle mich fachlich wie persönlich stetig weiter.</p>
@@ -212,52 +212,55 @@
                                                                         <section class="resume-skills-section resume-section">
                                                                                 <h3 class="resume-section-heading text-uppercase py-2 py-lg-3 py-3"><i class="resume-section-heading-icon bi bi-gear me-2"></i>Tech Stack</h3>
 
-                                                                                <div class="mb-4">
-                                                                                        <h4 class="text-uppercase text-secondary fs-6 fw-bold mb-2">Backend &amp; Plattformen</h4>
-                                                                                        <ul class="list-inline">
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Ruby</span></li>
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Ruby on Rails</span></li>
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">TypeScript</span></li>
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Node.js</span></li>
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">NestJS</span></li>
-                                                                                        </ul>
-                                                                                </div>
-                                                                                <div class="mb-4">
-                                                                                        <h4 class="text-uppercase text-secondary fs-6 fw-bold mb-2">Frontend &amp; Commerce</h4>
-                                                                                        <ul class="list-inline">
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">React</span></li>
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Next.js</span></li>
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Vue.js</span></li>
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Nuxt</span></li>
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Headless CMS</span></li>
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Shopify</span></li>
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Liquid Templates</span></li>
-                                                                                        </ul>
-                                                                                </div>
-                                                                                <div class="mb-4">
-                                                                                        <h4 class="text-uppercase text-secondary fs-6 fw-bold mb-2">Cloud &amp; DevOps</h4>
-                                                                                        <ul class="list-inline">
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">AWS</span></li>
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Azure</span></li>
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Google Cloud</span></li>
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Docker</span></li>
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Kamal</span></li>
-                                                                                        </ul>
-                                                                                </div>
-                                                                                <div>
-                                                                                        <h4 class="text-uppercase text-secondary fs-6 fw-bold mb-2">Daten, AI &amp; Integrationen</h4>
-                                                                                        <ul class="list-inline">
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">PostgreSQL</span></li>
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">MySQL</span></li>
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Redis</span></li>
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Elasticsearch</span></li>
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">HubSpot</span></li>
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Workflow Engines</span></li>
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">ERP-Integrationen</span></li>
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">Payment &amp; Billing APIs</span></li>
-                                                                                                <li class="list-inline-item"><span class="badge resume-skill-badge">LLM-gestützte Entwicklung</span></li>
-                                                                                        </ul>
-                                                                                </div>
+                                                                                <ul class="list-unstyled mb-0">
+                                                                                        <li class="mb-4">
+                                                                                                <div class="resume-skill-name text-uppercase text-secondary fs-6 fw-bold mb-2">Backend &amp; Plattformen</div>
+                                                                                                <ul class="list-inline">
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Ruby</span></li>
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Ruby on Rails</span></li>
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">TypeScript</span></li>
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Node.js</span></li>
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">NestJS</span></li>
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">REST APIs</span></li>
+                                                                                                </ul>
+                                                                                        </li>
+                                                                                        <li class="mb-4">
+                                                                                                <div class="resume-skill-name text-uppercase text-secondary fs-6 fw-bold mb-2">Frontend &amp; Commerce</div>
+                                                                                                <ul class="list-inline">
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">React</span></li>
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Next.js</span></li>
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Vue.js</span></li>
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Nuxt</span></li>
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Headless CMS</span></li>
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Shopify</span></li>
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Liquid Templates</span></li>
+                                                                                                </ul>
+                                                                                        </li>
+                                                                                        <li class="mb-4">
+                                                                                                <div class="resume-skill-name text-uppercase text-secondary fs-6 fw-bold mb-2">Cloud &amp; DevOps</div>
+                                                                                                <ul class="list-inline">
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">AWS</span></li>
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Azure</span></li>
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Google Cloud</span></li>
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Docker</span></li>
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Kamal</span></li>
+                                                                                                </ul>
+                                                                                        </li>
+                                                                                        <li>
+                                                                                                <div class="resume-skill-name text-uppercase text-secondary fs-6 fw-bold mb-2">Daten, AI &amp; Integrationen</div>
+                                                                                                <ul class="list-inline">
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">PostgreSQL</span></li>
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">MySQL</span></li>
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Redis</span></li>
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Elasticsearch</span></li>
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">HubSpot</span></li>
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Workflow Engines</span></li>
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">ERP-Integrationen</span></li>
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Payment &amp; Billing APIs</span></li>
+                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">LLM-gestützte Entwicklung</span></li>
+                                                                                                </ul>
+                                                                                        </li>
+                                                                                </ul>
 
                                                                         </section><!--//resume-section-->
 

--- a/index.html
+++ b/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="en">
 <head>
-        <title>Patrick Nüser – Senior Software Engineer</title>
+        <title></title>
 
         <!-- Meta -->
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="Lebenslauf von Patrick Nüser, Senior Software Engineer aus Hamburg.">
+        <meta name="description" content="">
         <meta name="author" content="Xiaoying Riley at 3rd Wave Media">
         <link rel="shortcut icon" href="favicon.ico">
 
@@ -23,6 +23,7 @@
 
         <!-- Theme CSS -->
         <link id="theme-style" rel="stylesheet" href="assets/css/shine.css">
+        <script defer src="assets/js/i18n.js"></script>
 
 </head>
 
@@ -35,10 +36,13 @@
                                 <div class="container-fluid">
                                         <div class="top-bar text-center position-relative">
                                                 <div class="top-bar-inner">
+                                                        <div class="language-switcher d-flex flex-column flex-sm-row align-items-center justify-content-center gap-2 mb-3">
+                                                                <label id="language-select-label" for="language-select" class="form-label mb-0"></label>
+                                                                <select id="language-select" class="form-select form-select-sm w-auto"></select>
+                                                        </div>
+                                                        <a class="btn btn-primary top-bar-cta" id="contact-button" href="#"></a>
 
-                                                        <a class="btn btn-primary top-bar-cta" href="mailto:mail@patrick-nueser.de">Kontakt</a>
-
-                                                        <div class="top-bar-note mt-3">Senior Software Engineer · Team-/Tech-Lead · Cloud &amp; AI Solutions</div>
+                                                        <div class="top-bar-note mt-3" id="top-bar-note"></div>
 
                                                 </div><!--//top-bar-inner-->
 
@@ -48,15 +52,10 @@
                                                 <div class="resume-header px-4 px-lg-5">
                                                         <div class="resume-profile-holder text-center">
                                                                 <img class="resume-profile-pic rounded-circle" src="assets/images/patrick-nüser.256x256.jpg" alt="image">
-
-                                                                <h2 class="resume-name text-uppercase">Patrick Nüser</h2>
-                                                                <div class="resume-role-title text-uppercase">Senior Software Engineer · Team-/Tech-Lead · Cloud &amp; AI Solutions</div>
+                                                                <h2 id="resume-name" class="resume-name text-uppercase"></h2>
+                                                                <div id="resume-role-title" class="resume-role-title text-uppercase"></div>
                                                                 <div class="resume-contact mt-4">
-                                                                        <ul class="resume-contact-list list-unstyled list-inline mb-0 justify-content-between">
-                                                                                <li class="list-inline-item me-md-3 me-lg-5"><i class="resume-contact-icon bi bi-telephone-inbound me-2"></i> <a href="tel:+4917662196684">+49 176 62196684</a></li>
-                                                                                <li class="list-inline-item me-md-3 me-lg-5"><i class="resume-contact-icon bi bi-envelope me-2"></i> <a href="mailto:mail@patrick-nueser.de">mail@patrick-nueser.de</a></li>
-                                                                                <li class="list-inline-item me-lg-5"><i class="resume-contact-icon bi bi-geo-alt me-2"></i> Hamburg, Deutschland</li>
-                                                                        </ul>
+                                                                        <ul id="contact-list" class="resume-contact-list list-unstyled list-inline mb-0 justify-content-between"></ul>
                                                                 </div><!--//resume-contact-->
                                                         </div><!--//profile-holder-->
                                                 </div><!--//resume-header-->
@@ -65,317 +64,66 @@
                                                         <div class="row">
                                                                 <div class="col-main col-12 col-lg-8 pe-lg-4">
                                                                         <section class="resume-summary-section resume-section">
-                                                                                <h3 class="resume-section-heading text-uppercase py-2 py-lg-3 py-3"><i class="resume-section-heading-icon bi bi-person me-2"></i>Profil</h3>
-                                                                                <div class="resume-summary-desc">
-                                                                                        <p>Ich bin Patrick, ein Software Engineer aus Hamburg. Komplexe Probleme motivieren mich, spannende Projekte treiben mich an. Dank meiner analytischen Denkweise erkenne und löse ich Herausforderungen schnell und strukturiert. Besonders im Team kommen meine kommunikativen Fähigkeiten zur Geltung – ich arbeite konstruktiv, lösungsorientiert und mit einem klaren Blick für Kosten und Nutzen.</p>
-                                                                                        <p>Durch meinen sportlichen Hintergrund habe ich Disziplin und Resilienz gelernt: dranzubleiben, wenn es hart wird, und Gelassenheit zu bewahren, wenn es die Situation erlaubt. Neue Technologien begeistern mich – ich entwickle mich fachlich wie persönlich stetig weiter.</p>
-                                                                                </div>
+                                                                                <h3 id="summary-heading" class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-person me-2"></i></h3>
+                                                                                <div id="summary-body" class="resume-summary-desc"></div>
                                                                         </section><!--//resume-section-->
 
                                                                         <hr>
 
                                                                         <section class="resume-experience-section resume-section">
-                                                                                <h3 class="resume-section-heading text-uppercase py-2 py-lg-3 py-3"><i class="resume-section-heading-icon bi bi-briefcase me-2"></i>Berufserfahrung</h3>
-                                                                                <div class="resume-timeline position-relative">
-                                                                                    <article class="resume-timeline-item position-relative pb-5">
-
-                                                                                            <div class="resume-timeline-item-header mb-2">
-
-                                                                                                    <div class="resume-position-meta d-flex justify-content-between mb-1">
-                                                                                                            <div class="resume-position-time">09/2024 – heute</div>
-                                                                                                            <div class="resume-company-name">1Komma5° Heartbeat GmbH · Hamburg</div>
-                                                                                                    </div>
-                                                                                                <h3 class="resume-position-title mb-1">Senior Softwareentwickler</h3>
-
-                                                                                            </div><!--//resume-timeline-item-header-->
-                                                                                            <div class="resume-timeline-item-desc">
-
-                                                                                                    <ul class="resume-timeline-list">
-                                                                                                            <li>Lead-Qualifizierungs-Service: Technische Projektleitung &amp; Systemdesign → ~10 Min. Zeitersparnis pro Lead, validierte/standardisierte Datenerfassung für Reporting &amp; Downstream-Systeme.</li>
-                                                                                                            <li>Architektur: ADR für Workflow Engines konzipiert → Standardisierung &amp; Skalierbarkeit von CRM-Integrationen.</li>
-                                                                                                            <li>Mentoring: Regelmäßige Pairing-Sessions; Vermittlung von Patterns &amp; Principles → Skill-Aufbau im Team.</li>
-                                                                                                            <li>AI/LLM: Mitgestaltung der LLM-Arbeitsgruppe → Standards für LLM-gestützte Entwicklung etabliert.</li>
-                                                                                                    </ul>
-
-                                                                                            </div><!--//resume-timeline-item-desc-->
-
-                                                                                    </article><!--//resume-timeline-item-->
-
-                                                                                    <article class="resume-timeline-item position-relative pb-5">
-
-                                                                                            <div class="resume-timeline-item-header mb-2">
-
-                                                                                                    <div class="resume-position-meta d-flex justify-content-between mb-1">
-                                                                                                            <div class="resume-position-time">03/2022 – 07/2024</div>
-                                                                                                            <div class="resume-company-name">Njiuko GmbH · Hamburg</div>
-                                                                                                    </div>
-                                                                                                <h3 class="resume-position-title mb-1">Softwareentwickler, Team-/Tech-Lead</h3>
-
-                                                                                            </div><!--//resume-timeline-item-header-->
-                                                                                            <div class="resume-timeline-item-desc">
-                                                                                                    <ul class="resume-timeline-list">
-                                                                                                            <li>Führung: Leitung von 8 Engineers (fachlich &amp; disziplinarisch: Gehaltsgespräche, Entwicklungspläne, OKRs, Recruiting, Offboarding).</li>
-                                                                                                            <li>Effizienz: Standardisierung der HubSpot-Entwicklung via Workflow Engines → Integrationsprojekte bis zu 50 % schneller.</li>
-                                                                                                            <li>Tech-Transformation: Stack-Wandel von Ruby on Rails zu TypeScript aktiv mitgestaltet.</li>
-                                                                                                            <li>Talententwicklung: Umschulung von Mobile- zu Web-Entwicklern → bessere Auslastung &amp; Skill-Diversität.</li>
-                                                                                                            <li>Business Impact: Große Aufträge gewonnen/gesichert (u. a. Gruner &amp; Jahr, Ysolutions); Budgetverantwortung, Angebote, technische Evaluationen.</li>
-                                                                                                    </ul>
-
-                                                                                            </div><!--//resume-timeline-item-desc-->
-
-                                                                                    </article><!--//resume-timeline-item-->
-                                                                                    <article class="resume-timeline-item position-relative pb-5">
-
-                                                                                            <div class="resume-timeline-item-header mb-2">
-
-                                                                                                    <div class="resume-position-meta d-flex justify-content-between mb-1">
-                                                                                                            <div class="resume-position-time">01/2019 – 03/2022</div>
-                                                                                                            <div class="resume-company-name">tourrise GmbH · Hamburg</div>
-                                                                                                    </div>
-                                                                                                <h3 class="resume-position-title mb-1">Technischer Mitgründer (CTO)</h3>
-
-                                                                                            </div><!--//resume-timeline-item-header-->
-                                                                                            <div class="resume-timeline-item-desc">
-                                                                                                    <ul class="resume-timeline-list">
-                                                                                                            <li>Produktaufbau: Architektur &amp; Umsetzung der initialen Infrastruktur (Mandantenfähigkeit, Payment, Front-/Mid-/Backoffice).</li>
-                                                                                                            <li>Integrationen: Schnittstellen zu Flugdienstleistern, Rechnungsstellung, Buchhaltung.</li>
-                                                                                                            <li>Impact: 2 zahlende Kunden (~200 k ARR) → Produkt im Markt etabliert.</li>
-                                                                                                            <li>Tech: Ruby on Rails, Docker, Kamal.</li>
-                                                                                                    </ul>
-
-                                                                                            </div><!--//resume-timeline-item-desc-->
-
-                                                                                    </article><!--//resume-timeline-item-->
-                                                                                    <article class="resume-timeline-item position-relative pb-5">
-
-                                                                                            <div class="resume-timeline-item-header mb-2">
-
-                                                                                                    <div class="resume-position-meta d-flex justify-content-between mb-1">
-                                                                                                            <div class="resume-position-time">03/2017 – 07/2022</div>
-                                                                                                            <div class="resume-company-name">Selbstständig · Remote/Hamburg</div>
-                                                                                                    </div>
-                                                                                                <h3 class="resume-position-title mb-1">Full-Stack Entwickler &amp; Berater</h3>
-
-                                                                                            </div><!--//resume-timeline-item-header-->
-                                                                                            <div class="resume-timeline-item-desc">
-                                                                                                    <ul class="resume-timeline-list">
-                                                                                                            <li>OMR: Reviews-Produkt mitgeplant; Kerninfrastruktur implementiert.</li>
-                                                                                                            <li>Peek &amp; Cloppenburg: Corporate-Sites modernisiert → Next.js + Headless CMS.</li>
-                                                                                                            <li>XING: GDPR-Infrastruktur im „Startpage“-Team mitkonzipiert &amp; entwickelt.</li>
-                                                                                                            <li>A.W. Niemeyer: Shopify-Umzug, Liquid Templates &amp; Custom Apps; ERP-Modernisierung für Echtzeit-Verfügbarkeiten.</li>
-                                                                                                            <li>Weitere Projekte: Technische Architektur/Planung &amp; strategische Beratung (KMU/Enterprise).</li>
-                                                                                                    </ul>
-
-                                                                                            </div><!--//resume-timeline-item-desc-->
-
-                                                                                    </article><!--//resume-timeline-item-->
-                                                                                    <article class="resume-timeline-item position-relative">
-
-                                                                                            <div class="resume-timeline-item-header mb-2">
-
-                                                                                                    <div class="resume-position-meta d-flex justify-content-between mb-1">
-                                                                                                            <div class="resume-position-time">06/2014 – 03/2017</div>
-                                                                                                            <div class="resume-company-name">Njiuko GmbH · Hamburg</div>
-                                                                                                    </div>
-                                                                                                <h3 class="resume-position-title mb-1">Backend Entwickler</h3>
-
-                                                                                            </div><!--//resume-timeline-item-header-->
-                                                                                            <div class="resume-timeline-item-desc">
-                                                                                                    <ul class="resume-timeline-list">
-                                                                                                            <li>Entwicklung neuer und bestehender Plattformen (Protonet SOUL, Lagardère Sports Keeper, Protonet Leads App).</li>
-                                                                                                            <li>DevOps &amp; Betrieb hochverfügbarer Systeme; Code Reviews &amp; Pair Programming.</li>
-                                                                                                    </ul>
-
-                                                                                            </div><!--//resume-timeline-item-desc-->
-
-                                                                                    </article><!--//resume-timeline-item-->
-                                                                    </div><!--//resume-timeline-->
+                                                                                <h3 id="experience-heading" class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-briefcase me-2"></i></h3>
+                                                                                <div id="experience-timeline" class="resume-timeline position-relative"></div>
                                                                         </section><!--//resume-experience-section-->
 
                                                                         <hr>
 
                                                                         <section class="resume-section">
-                                                                                <h3 class="resume-section-heading text-uppercase py-2 py-lg-3 py-3"><i class="resume-section-heading-icon bi bi-collection me-2"></i>Weitere Erfahrungen (Auswahl)</h3>
-                                                                                <ul class="list-unstyled mb-0">
-                                                                                        <li><strong>Selbstständig (2012–2014):</strong> Buchungssystem (Kontingente, Rollen, REST, Easybill-/Flightstats); Radsportkarte Fuerteventura (mit Hannes Hawaii Tours, Adobe Suite).</li>
-                                                                                        <li><strong>Hannes Hawaii Tours (2009–2014):</strong> Tourguide &amp; Reiseleiter, Gruppen bis 120 Personen, Teamkoordination.</li>
-                                                                                        <li><strong>Jack Wolfskin (2010–2012):</strong> Verkauf von Funktionstextilien &amp; Zubehör.</li>
-                                                                                        <li><strong>SCOL Skireisen (2006–2008):</strong> Leitung von Jugend- &amp; Familiengruppen (Saison).</li>
-                                                                                        <li><strong>Sport Reckemeier (2006–2008):</strong> Laufschuhfachverkäufer; Vertretung Geschäftsführung, Jahresorder.</li>
-                                                                                        <li><strong>Etzhorner Krug (2004–2006):</strong> Tellerwäscher (erster Job).</li>
-                                                                                        <li><strong>Zivildienst (08/2007 – 06/2008):</strong> Landesbildungszentrum für Hörgeschädigte, Oldenburg.</li>
-                                                                                </ul>
+                                                                                <h3 id="additional-experience-heading" class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-collection me-2"></i></h3>
+                                                                                <ul id="additional-experience-list" class="list-unstyled mb-0"></ul>
                                                                         </section><!--//resume-section-->
                                                                 </div><!--//col-8-->
                                                                 <div class="col-12 col-lg-4 ps-lg-4">
 
                                                                         <section class="resume-skills-section resume-section">
-                                                                                <h3 class="resume-section-heading text-uppercase py-2 py-lg-3 py-3"><i class="resume-section-heading-icon bi bi-gear me-2"></i>Tech Stack</h3>
+                                                                                <h3 id="tech-stack-heading" class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-gear me-2"></i></h3>
 
-                                                                                <ul class="list-unstyled mb-0">
-                                                                                        <li class="mb-4">
-                                                                                                <div class="resume-skill-name text-uppercase text-secondary fs-6 fw-bold mb-2">Backend &amp; Plattformen</div>
-                                                                                                <ul class="list-inline">
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Ruby</span></li>
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Ruby on Rails</span></li>
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">TypeScript</span></li>
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Node.js</span></li>
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">NestJS</span></li>
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">REST APIs</span></li>
-                                                                                                </ul>
-                                                                                        </li>
-                                                                                        <li class="mb-4">
-                                                                                                <div class="resume-skill-name text-uppercase text-secondary fs-6 fw-bold mb-2">Frontend &amp; Commerce</div>
-                                                                                                <ul class="list-inline">
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">React</span></li>
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Next.js</span></li>
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Vue.js</span></li>
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Nuxt</span></li>
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Headless CMS</span></li>
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Shopify</span></li>
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Liquid Templates</span></li>
-                                                                                                </ul>
-                                                                                        </li>
-                                                                                        <li class="mb-4">
-                                                                                                <div class="resume-skill-name text-uppercase text-secondary fs-6 fw-bold mb-2">Cloud &amp; DevOps</div>
-                                                                                                <ul class="list-inline">
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">AWS</span></li>
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Azure</span></li>
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Google Cloud</span></li>
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Docker</span></li>
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Kamal</span></li>
-                                                                                                </ul>
-                                                                                        </li>
-                                                                                        <li>
-                                                                                                <div class="resume-skill-name text-uppercase text-secondary fs-6 fw-bold mb-2">Daten, AI &amp; Integrationen</div>
-                                                                                                <ul class="list-inline">
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">PostgreSQL</span></li>
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">MySQL</span></li>
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Redis</span></li>
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Elasticsearch</span></li>
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">HubSpot</span></li>
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Workflow Engines</span></li>
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">ERP-Integrationen</span></li>
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">Payment &amp; Billing APIs</span></li>
-                                                                                                        <li class="list-inline-item"><span class="badge resume-skill-badge">LLM-gestützte Entwicklung</span></li>
-                                                                                                </ul>
-                                                                                        </li>
-                                                                                </ul>
+                                                                                <ul id="tech-stack-list" class="list-unstyled mb-0"></ul>
 
                                                                         </section><!--//resume-section-->
 
                                                                         <hr>
 
                                                                         <section class="resume-skills-section resume-section">
-                                                                                <h3 class="resume-section-heading text-uppercase py-2 py-lg-3 py-3"><i class="resume-section-heading-icon bi bi-person-gear me-2"></i>Soft Skills</h3>
-                                                                                <ul class="list-inline">
-                                                                            <li class="list-inline-item"><span class="badge resume-skill-badge">Teamführung &amp; Coaching</span></li>
-                                                                            <li class="list-inline-item"><span class="badge resume-skill-badge">Architektur &amp; Systemdesign</span></li>
-                                                                            <li class="list-inline-item"><span class="badge resume-skill-badge">Stakeholder-Management</span></li>
-                                                                            <li class="list-inline-item"><span class="badge resume-skill-badge">Produktfokus &amp; Kosten-Nutzen</span></li>
-                                                                            <li class="list-inline-item"><span class="badge resume-skill-badge">Mentoring &amp; Pairing</span></li>
-                                                                            <li class="list-inline-item"><span class="badge resume-skill-badge">Code-Quality &amp; Reviews</span></li>
-                                                                    </ul>
+                                                                                <h3 id="soft-skills-heading" class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-person-gear me-2"></i></h3>
+                                                                                <ul id="soft-skills-list" class="list-inline"></ul>
                                                                         </section><!--//resume-section-->
 
                                                                         <hr>
 
                                                                         <section class="resume-projects-section resume-section">
-                                                                                <h3 class="resume-section-heading text-uppercase py-2 py-lg-3 py-3"><i class="resume-section-heading-icon bi bi-code-slash me-2"></i>Projekte (Auswahl)</h3>
-                                                                                <div class="item">
-                                                                                        <h4 class="item-heading"><i class="item-icon bi bi-square-fill me-2"></i>OMR – Reviews</h4>
-                                                                                        <div class="item-desc">
-                                                                                                Reviews-Produkt mitgeplant und Kernkomponenten der skalierbaren Architektur implementiert.
-                                                                                        </div>
-                                                                                </div><!--//item-->
-                                                                                <div class="item">
-                                                                                        <h4 class="item-heading"><i class="item-icon bi bi-square-fill me-2"></i>Peek &amp; Cloppenburg – Corporate Sites</h4>
-                                                                                        <div class="item-desc">
-                                                                                                Corporate-Websites modernisiert: Next.js + Headless CMS für bessere Performance &amp; effizientere Workflows.
-                                                                                        </div>
-                                                                                </div><!--//item-->
-                                                                                <div class="item">
-                                                                                        <h4 class="item-heading"><i class="item-icon bi bi-square-fill me-2"></i>XING – GDPR-Infrastruktur</h4>
-                                                                                        <div class="item-desc">
-                                                                                                Compliance-fähige Systeme im „Startpage“-Team mitkonzipiert und entwickelt, Fokus auf Stabilität &amp; Wartbarkeit.
-                                                                                        </div>
-                                                                                </div><!--//item-->
-                                                                                <div class="item">
-                                                                                        <h4 class="item-heading"><i class="item-icon bi bi-square-fill me-2"></i>A.W. Niemeyer – Shopify &amp; ERP</h4>
-                                                                                        <div class="item-desc">
-                                                                                                Shopify-Migration inkl. Custom Apps; ERP-Modernisierung für Echtzeit-Verfügbarkeiten im Handel.
-                                                                                        </div>
-                                                                                </div><!--//item-->
-
+                                                                                <h3 id="projects-heading" class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-code-slash me-2"></i></h3>
+                                                                                <div id="projects-list"></div>
                                                                         </section>
 
                                                                         <hr>
 
                                                                         <section class="resume-educate-section resume-section">
-                                                                                <h3 class="resume-section-heading text-uppercase py-2 py-lg-3 py-3"><i class="resume-section-heading-icon bi bi-book me-2"></i>Ausbildung</h3>
-                                                                                <ul class="list-unstyled">
-                                                                                    <li class="mb-2">
-                                                                                        <div class="resume-degree font-weight-bold">B.Sc. Informatik</div>
-                                                                                        <div class="resume-degree-org">Universität Osnabrück</div>
-                                                                                        <div class="resume-degree-time">Abschluss 12/2013</div>
-                                                                                        <div class="resume-degree-desc">Abschlussarbeit: Entwicklung einer Livestreaming- &amp; VOD-Komponente für ein Online-Rückenstudio. Tutorien: Software Engineering (04–07/2013); Gleichungsbasierte Modelle I (04–07/2012).</div>
-                                                                                    </li>
-                                                                                    <li>
-                                                                                        <div class="resume-degree font-weight-bold">Auslandssemester Informatik</div>
-                                                                                        <div class="resume-degree-org">Universität Stockholm</div>
-                                                                                        <div class="resume-degree-time">08/2012 – 02/2013</div>
-                                                                                        <div class="resume-degree-desc">Schwerpunkte: Data Mining, Network Security, Computer Security.</div>
-                                                                                    </li>
-                                                                            </ul>
+                                                                                <h3 id="education-heading" class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-book me-2"></i></h3>
+                                                                                <ul id="education-list" class="list-unstyled"></ul>
                                                                         </section><!--//resume-section-->
 
                                                                         <hr>
 
                                                                         <section class="resume-lang-section resume-section">
-                                                                                <h3 class="resume-section-heading text-uppercase py-2 py-lg-3 py-3"><i class="resume-section-heading-icon bi bi-translate me-2"></i>Sprachen</h3>
-                                                                                 <ul class="list-unstyled resume-lang-list">
-                                                                                    <li class="mb-2">
-                                                                                        <div class="resume-lang-name">Deutsch (Muttersprache)</div>
-                                                                                        <div class="resume-level-indicator row gx-0 flex-nowrap">
-                                                                                                <div class="col"><span class="item item-full"></span></div>
-                                                                                                <div class="col"><span class="item item-full"></span></div>
-                                                                                                <div class="col"><span class="item item-full"></span></div>
-                                                                                                <div class="col"><span class="item item-full"></span></div>
-                                                                                                <div class="col"><span class="item item-full"></span></div>
-                                                                                                <div class="col"><span class="item item-full"></span></div>
-                                                                                                <div class="col"><span class="item item-full"></span></div>
-                                                                                                <div class="col"><span class="item item-full"></span></div>
-                                                                                                <div class="col"><span class="item item-full"></span></div>
-                                                                                                <div class="col"><span class="item item-full"></span></div>
-                                                                                        </div><!--//resume-level-indicator-->
-                                                                                    </li>
-                                                                                     <li>
-                                                                                        <div class="resume-lang-name">Englisch (fließend)</div>
-                                                                                        <div class="resume-level-indicator row gx-0 flex-nowrap">
-                                                                                                <div class="col"><span class="item item-full"></span></div>
-                                                                                                <div class="col"><span class="item item-full"></span></div>
-                                                                                                <div class="col"><span class="item item-full"></span></div>
-                                                                                                <div class="col"><span class="item item-full"></span></div>
-                                                                                                <div class="col"><span class="item item-full"></span></div>
-                                                                                                <div class="col"><span class="item item-full"></span></div>
-                                                                                                <div class="col"><span class="item item-full"></span></div>
-                                                                                                <div class="col"><span class="item item-full"></span></div>
-                                                                                                <div class="col"><span class="item item-full"></span></div>
-                                                                                                <div class="col"><span class="item item-half"></span></div>
-                                                                                        </div><!--//resume-level-indicator-->
-                                                                                    </li>
-                                                                                </ul>
+                                                                                <h3 id="languages-heading" class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-translate me-2"></i></h3>
+                                                                                 <ul id="languages-list" class="list-unstyled resume-lang-list"></ul>
                                                                         </section>
 
                                                                         <hr>
 
                                                                         <section class="resume-interests-section resume-section">
-                                                                                <h3 class="resume-section-heading text-uppercase py-2 py-lg-3 py-3"><i class="resume-section-heading-icon bi bi-sun me-2"></i>Interessen</h3>
-                                                                                <ul class="list-inline">
-                                                                                    <li class="list-inline-item"><span class="badge resume-skill-badge">Langjähriger Leistungssport (Triathlon, Laufen, Rennrad)</span></li>
-                                                                                    <li class="list-inline-item"><span class="badge resume-skill-badge">Kochen &amp; Essen</span></li>
-                                                                                    <li class="list-inline-item"><span class="badge resume-skill-badge">Tech &amp; Games</span></li>
-                                                                                </ul>
+                                                                                <h3 id="interests-heading" class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-sun me-2"></i></h3>
+                                                                                <ul id="interests-list" class="list-inline"></ul>
                                                                         </section>
 
 


### PR DESCRIPTION
## Summary
- replace the Tech Stack progress bars with grouped badge lists for backend, frontend, cloud, and data/AI topics
- highlight additional technologies mentioned elsewhere in the CV such as Headless CMS, Shopify, HubSpot, workflow engines, ERP integrations, payment APIs, and Kamal

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68cedc9bcdf0832cb159fadd5d3defdb