### PR TITLE
Add print layout overrides

### DIFF
--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -1,0 +1,253 @@
+/*
+ * Print-specific layout overrides for the résumé.
+ */
+@media print {
+  @page {
+    size: A4;
+    margin: 12mm;
+  }
+
+  html {
+    background: #ffffff !important;
+  }
+
+  body {
+    background: #ffffff !important;
+    color: #000000 !important;
+    font-size: 12pt;
+    line-height: 1.5;
+  }
+
+  * {
+    box-shadow: none !important;
+  }
+
+  .container-fluid,
+  .main-content-wrapper,
+  .resume-wrapper,
+  .resume-header,
+  .resume-body,
+  .resume-section,
+  .resume-contact {
+    background: #ffffff !important;
+    color: #000000 !important;
+  }
+
+  .top-bar,
+  .language-switcher,
+  #language-select,
+  #language-select-label,
+  #contact-button,
+  #top-bar-note,
+  .top-bar-cta,
+  .footer {
+    display: none !important;
+  }
+
+  .main-content-wrapper {
+    padding: 0 !important;
+  }
+
+  .container-fluid {
+    padding: 0 !important;
+  }
+
+  .resume-wrapper {
+    margin: 0 !important;
+    padding: 0 !important;
+    box-shadow: none !important;
+    border-radius: 0 !important;
+    max-width: none !important;
+  }
+
+  .resume-header {
+    padding: 0 0 1.5rem 0 !important;
+    border-bottom: 2px solid #000000;
+  }
+
+  .resume-profile-holder {
+    text-align: left !important;
+    display: grid !important;
+    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-areas:
+      "photo name"
+      "photo title"
+      "photo contact";
+    column-gap: 1.25rem;
+    row-gap: 0.35rem;
+    align-items: center;
+  }
+
+  .resume-profile-pic {
+    grid-area: photo;
+    position: static !important;
+    margin: 0;
+    max-width: 110px;
+    height: auto;
+    border: 2px solid #000000;
+  }
+
+  .resume-name {
+    grid-area: name;
+    letter-spacing: 0.1rem !important;
+    font-size: 1.8rem !important;
+    color: #000000 !important;
+    margin-bottom: 0.15rem !important;
+  }
+
+  .resume-role-title {
+    grid-area: title;
+    letter-spacing: 0.1rem !important;
+    color: #333333 !important;
+    font-size: 1.1rem !important;
+  }
+
+  .resume-contact {
+    grid-area: contact;
+    border: 0 !important;
+    padding: 0 !important;
+    margin-top: 0.5rem !important;
+    font-size: 10pt;
+  }
+
+  .resume-contact-list {
+    margin: 0 !important;
+    display: grid !important;
+    gap: 0.25rem 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    padding: 0 !important;
+    list-style: none !important;
+  }
+
+  .resume-contact-list li {
+    display: flex !important;
+    align-items: center;
+    gap: 0.35rem;
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .resume-contact-icon {
+    color: #000000 !important;
+  }
+
+  .resume-body {
+    padding: 1.5rem 0 0 0 !important;
+    color: #000000 !important;
+  }
+
+  .resume-body .row {
+    display: grid !important;
+    grid-template-columns: minmax(0, 2.1fr) minmax(0, 1fr);
+    gap: 1.5rem;
+    margin: 0 !important;
+  }
+
+  .resume-body .row > div {
+    width: auto !important;
+    max-width: none !important;
+    flex: none !important;
+    padding: 0 !important;
+  }
+
+  .resume-section {
+    margin-bottom: 1.25rem !important;
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+
+  .resume-section-heading {
+    color: #000000 !important;
+    letter-spacing: 0.12rem !important;
+  }
+
+  .resume-section-heading-icon {
+    background: transparent !important;
+    color: #000000 !important;
+    border: 1px solid currentColor;
+  }
+
+  .resume-timeline {
+    padding-left: 1.5rem !important;
+  }
+
+  .resume-timeline:before {
+    left: 6px !important;
+    background: rgba(0, 0, 0, 0.35) !important;
+  }
+
+  .resume-timeline-item {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .resume-timeline-item:before {
+    border-color: rgba(0, 0, 0, 0.35) !important;
+    background: #ffffff !important;
+  }
+
+  .resume-timeline-list li,
+  .resume-projects-section .item,
+  .resume-educate-section li,
+  .resume-lang-section li,
+  .resume-interests-section li,
+  .resume-skills-section li {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .resume-company-name,
+  .resume-position-title,
+  .resume-degree,
+  .resume-lang-name,
+  .resume-skill-name {
+    color: #000000 !important;
+  }
+
+  .resume-company-name {
+    background: transparent !important;
+    padding: 0 !important;
+  }
+
+  .resume-progress,
+  .resume-skill-badge,
+  .resume-level-indicator .item {
+    background: #e1e5ea !important;
+    color: #000000 !important;
+  }
+
+  .resume-progress-bar {
+    background: #4d5666 !important;
+  }
+
+  .resume-level-indicator .item.item-full,
+  .resume-level-indicator .item.item-half::after {
+    background: #888888 !important;
+  }
+
+  .resume-projects-section .item-heading a {
+    color: #000000 !important;
+  }
+
+  .resume-skill-badge {
+    border: 1px solid rgba(0, 0, 0, 0.15);
+  }
+
+  #summary-body,
+  p,
+  li {
+    color: #000000 !important;
+  }
+
+  a,
+  a:visited {
+    color: inherit !important;
+    text-decoration: none !important;
+  }
+
+  hr {
+    color: rgba(0, 0, 0, 0.3) !important;
+    background-color: rgba(0, 0, 0, 0.3) !important;
+    border-color: rgba(0, 0, 0, 0.3) !important;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
 
         <!-- Theme CSS -->
         <link id="theme-style" rel="stylesheet" href="assets/css/shine.css">
+        <link rel="stylesheet" href="assets/css/print.css" media="print">
         <script defer src="assets/js/i18n.js"></script>
 
 </head>


### PR DESCRIPTION
## Summary
- load a dedicated print stylesheet alongside the existing theme
- restyle the résumé for paper with a white layout, reorganised header, and two-column body grid
- hide interactive UI chrome (language switcher, contact button, footer) and add page-break guards for cleaner printouts

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cee2cd1de4832ca4fce2b567cac0a3