### PR TITLE
Redesign tech stack presentation

### DIFF
--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -264,6 +264,39 @@ function renderTechStack(data) {
   }
 
   list.innerHTML = '';
+  const groups = Array.isArray(data?.groups) ? data.groups : [];
+  if (groups.length > 0) {
+    groups.forEach((group) => {
+      const li = document.createElement('li');
+      li.className = 'mb-3';
+
+      if (group?.title) {
+        const title = document.createElement('div');
+        title.className = 'resume-skill-name';
+        title.textContent = group.title;
+        li.appendChild(title);
+      }
+
+      const groupItems = Array.isArray(group?.items) ? group.items : [];
+      if (groupItems.length > 0) {
+        const badges = document.createElement('div');
+        badges.className = 'd-flex flex-wrap gap-2 mt-2';
+
+        groupItems.forEach((item) => {
+          const badge = document.createElement('span');
+          badge.className = 'badge resume-skill-badge';
+          badge.textContent = item;
+          badges.appendChild(badge);
+        });
+
+        li.appendChild(badges);
+      }
+
+      list.appendChild(li);
+    });
+    return;
+  }
+
   const items = Array.isArray(data?.items) ? data.items : [];
   items.forEach((item) => {
     const li = document.createElement('li');

--- a/assets/lang/de.json
+++ b/assets/lang/de.json
@@ -57,7 +57,7 @@
         "title": "Senior Softwareentwickler",
         "bullets": [
           "Lead-Qualifizierungs-Service: Technische Projektleitung & Systemdesign → ~10 Min. Zeitersparnis pro Lead, validierte/standardisierte Datenerfassung für Reporting & Downstream-Systeme.",
-          "Architektur: ADR für Workflow Engines konzipiert → Standardisierung & Skalierbarkeit von CRM-Integrationen.",
+          "Architektur: ADR für Workflow Engines & Zoho CRM konzipiert → Standardisierung & Skalierbarkeit von CRM-Integrationen.",
           "Mentoring: Regelmäßige Pairing-Sessions; Vermittlung von Patterns & Principles → Skill-Aufbau im Team.",
           "AI/LLM: Mitgestaltung der LLM-Arbeitsgruppe → Standards für LLM-gestützte Entwicklung etabliert."
         ]
@@ -143,14 +143,51 @@
   },
   "techStack": {
     "heading": "Tech Stack",
-    "progressAriaLabel": "Kenntnisstand",
-    "items": [
-      { "name": "Ruby & Rails", "value": 95 },
-      { "name": "TypeScript, Node.js & NestJS", "value": 92 },
-      { "name": "React, Next.js, Vue & Nuxt", "value": 90 },
-      { "name": "Cloud (AWS, Azure, GCP) & DevOps", "value": 88 },
-      { "name": "Datenbanken & Suche (Postgres, MySQL, Redis, Elasticsearch)", "value": 86 },
-      { "name": "AI/LLM-gestützte Entwicklung", "value": 82 }
+    "groups": [
+      {
+        "title": "Sprachen & Frameworks",
+        "items": [
+          "Ruby & Ruby on Rails",
+          "TypeScript, Node.js & NestJS",
+          "React, Next.js, Vue & Nuxt"
+        ]
+      },
+      {
+        "title": "Cloud & Betrieb",
+        "items": [
+          "AWS, Azure & GCP",
+          "Docker & Kamal"
+        ]
+      },
+      {
+        "title": "Daten & Speicher",
+        "items": [
+          "Postgres & MySQL",
+          "Redis & Elasticsearch"
+        ]
+      },
+      {
+        "title": "CRM & Automatisierung",
+        "items": [
+          "Zoho CRM",
+          "HubSpot",
+          "Workflow Engines & Integrationen"
+        ]
+      },
+      {
+        "title": "Commerce & Content-Plattformen",
+        "items": [
+          "Shopify & Liquid",
+          "Headless-CMS-Architekturen"
+        ]
+      },
+      {
+        "title": "KI & Enablement",
+        "items": [
+          "LLM-gestützte Entwicklung",
+          "KI-Experimente & Prototyping"
+        ]
+      }
     ]
   },
   "softSkills": {

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -57,7 +57,7 @@
         "title": "Senior Software Engineer",
         "bullets": [
           "Lead qualification service: technical project leadership & system design → ~10 minutes saved per lead, validated/standardized data capture for reporting & downstream systems.",
-          "Architecture: designed ADRs for workflow engines → standardized & scalable CRM integrations.",
+          "Architecture: designed ADRs for workflow engines & Zoho CRM → standardized & scalable CRM integrations.",
           "Mentoring: regular pairing sessions; sharing patterns & principles → capability building within the team.",
           "AI/LLM: co-shaped the LLM working group → established standards for LLM-assisted development."
         ]
@@ -143,14 +143,51 @@
   },
   "techStack": {
     "heading": "Tech Stack",
-    "progressAriaLabel": "Proficiency",
-    "items": [
-      { "name": "Ruby & Rails", "value": 95 },
-      { "name": "TypeScript, Node.js & NestJS", "value": 92 },
-      { "name": "React, Next.js, Vue & Nuxt", "value": 90 },
-      { "name": "Cloud (AWS, Azure, GCP) & DevOps", "value": 88 },
-      { "name": "Databases & search (Postgres, MySQL, Redis, Elasticsearch)", "value": 86 },
-      { "name": "AI/LLM-assisted development", "value": 82 }
+    "groups": [
+      {
+        "title": "Languages & Frameworks",
+        "items": [
+          "Ruby & Ruby on Rails",
+          "TypeScript, Node.js & NestJS",
+          "React, Next.js, Vue & Nuxt"
+        ]
+      },
+      {
+        "title": "Cloud & Operations",
+        "items": [
+          "AWS, Azure & GCP",
+          "Docker & Kamal"
+        ]
+      },
+      {
+        "title": "Data & Storage",
+        "items": [
+          "Postgres & MySQL",
+          "Redis & Elasticsearch"
+        ]
+      },
+      {
+        "title": "CRM & Automation",
+        "items": [
+          "Zoho CRM",
+          "HubSpot",
+          "Workflow engines & integrations"
+        ]
+      },
+      {
+        "title": "Commerce & Content",
+        "items": [
+          "Shopify & Liquid",
+          "Headless CMS architectures"
+        ]
+      },
+      {
+        "title": "AI & Enablement",
+        "items": [
+          "LLM-assisted development",
+          "AI experimentation & prototyping"
+        ]
+      }
     ]
   },
   "softSkills": {


### PR DESCRIPTION
## Summary
- replace the progress-bar tech stack with grouped technology badges and keep a fallback for legacy data
- expand both language files with the new tech stack groups and mention Zoho CRM in the 1Komma5° experience entry

## Testing
- python -m json.tool assets/lang/en.json
- python -m json.tool assets/lang/de.json

------
https://chatgpt.com/codex/tasks/task_e_68cef15622d8832ca1187d18611697a8