### PR TITLE
Replace language dropdown with buttons

### DIFF
--- a/assets/lang/de.json
+++ b/assets/lang/de.json
@@ -8,8 +8,8 @@
     "label": "Sprache",
     "ariaLabel": "Sprache auswählen",
     "options": [
-      { "value": "en", "label": "Englisch" },
-      { "value": "de", "label": "Deutsch" }
+      { "value": "en", "label": "Englisch", "shortLabel": "EN" },
+      { "value": "de", "label": "Deutsch", "shortLabel": "DE" }
     ]
   },
   "topBar": {

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -8,8 +8,8 @@
     "label": "Language",
     "ariaLabel": "Select language",
     "options": [
-      { "value": "en", "label": "English" },
-      { "value": "de", "label": "German" }
+      { "value": "en", "label": "English", "shortLabel": "EN" },
+      { "value": "de", "label": "German", "shortLabel": "DE" }
     ]
   },
   "topBar": {

--- a/index.html
+++ b/index.html
@@ -22,11 +22,8 @@
     <script defer src="assets/fontawesome/js/all.js"></script>
 
         <!-- Theme CSS -->
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-select@1.14.0-beta3/dist/css/bootstrap-select.min.css">
         <link id="theme-style" rel="stylesheet" href="assets/css/shine.css">
-        <script defer src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"></script>
         <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-        <script defer src="https://cdn.jsdelivr.net/npm/bootstrap-select@1.14.0-beta3/dist/js/bootstrap-select.min.js"></script>
         <script defer src="assets/js/i18n.js"></script>
 
 </head>
@@ -41,8 +38,8 @@
                                         <div class="resume-wrapper mx-auto rounded-2">
                                                 <div class="resume-actions d-flex flex-column flex-sm-row align-items-center justify-content-center justify-content-sm-end gap-3 w-100 px-4 px-lg-5 pt-4 d-print-none">
                                                         <div class="language-switcher d-flex flex-column flex-sm-row align-items-center justify-content-center justify-content-sm-end gap-2">
-                                                                <label id="language-select-label" for="language-select" class="form-label mb-0"></label>
-                                                                <select id="language-select" class="selectpicker form-select form-select-sm w-auto" data-style="btn-outline-secondary btn-sm" data-width="fit" data-size="5"></select>
+                                                                <span id="language-select-label" class="form-label mb-0"></span>
+                                                                <div id="language-select" class="btn-group btn-group-sm" role="group"></div>
                                                         </div>
                                                         <a class="btn btn-primary" id="contact-button" href="#"></a>
                                                 </div>


### PR DESCRIPTION
## Summary
- replace the language dropdown in the header with a compact EN/DE button group
- update the i18n logic to render and handle the new buttons while removing the old selectpicker integration
- extend the language metadata with short labels for the button texts

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68ceffea416c832ca5ad82e23a4051e7