### PR TITLE
Add unit tests for build script and document workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 config.codekit3
+node_modules/
+

--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -1,0 +1,14 @@
+{
+  "tag-pair": true,
+  "tagname-lowercase": true,
+  "attr-lowercase": true,
+  "attr-value-double-quotes": true,
+  "attr-no-duplication": true,
+  "spec-char-escape": true,
+  "src-not-empty": true,
+  "id-unique": true,
+  "title-require": true,
+  "head-script-disabled": false,
+  "style-disabled": false,
+  "space-tab-mixed-disabled": false
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,37 +4,40 @@
 These instructions apply to the entire repository.
 
 ## Project Overview
-This project is a fully static résumé site. Everything runs in the browser with plain HTML, CSS, and JavaScript that work when the files are served from a basic static web host.
+This project publishes Patrick Nüser's résumé as a fully static website. All language-specific content is stored in JSON files and rendered into prebuilt HTML pages via a small Node-based pipeline so the site works on GitHub Pages without requiring client-side JavaScript.
+
+## Build & Localisation Workflow
+- `pnpm build` runs `scripts/build.mjs`, rendering `templates/resume.mustache` with the locale data from `assets/lang/*.json` and the configuration in `build.config.json`.
+- Whenever you edit the template, localisation JSON, build configuration, or the build script itself, rerun `pnpm build` and commit the regenerated `index.html` files to keep them in sync.
+- The build script also ensures that each language version links to the others. Preserve those cross-links when making changes.
 
 ## Tooling & Dependencies
-- Keep the stack simple: do not add frontend frameworks, component compilers, build pipelines, or runtime dependencies (React, Vue, Angular, Webpack, Vite, etc.).
-- Stick to vanilla ES6 modules/DOM APIs, hand-authored HTML, and plain CSS (generated from the existing SCSS files).
-- Third-party assets already in the project (Bootstrap CSS, Bootstrap Icons, Font Awesome) may be used as-is, but avoid introducing new library CDNs unless absolutely necessary.
+- Keep the stack lightweight: no frontend frameworks, bundlers, or runtime dependencies such as React, Vue, Angular, Webpack, or Vite.
+- Use pnpm for dependency management. All tooling lives in `devDependencies` and should stay minimal.
 
 ## HTML Guidelines
-- Preserve semantic markup and the existing document outline.
-- Many elements are referenced by `assets/js/i18n.js` via hard-coded IDs (e.g., `language-select`, `resume-name`, `experience-timeline`, etc.). Do not rename or remove these IDs without updating the script and the translations accordingly.
-- Keep accessibility attributes (alt text, aria labels, roles) accurate whenever you change content.
+- Preserve the semantic structure of the résumé template and maintain the document outline.
+- IDs referenced by `assets/js/i18n.js` must remain stable; update the script and translations in tandem if you need to rename them.
+- Maintain accurate accessibility attributes (alt text, aria labels, roles) when adjusting markup or content.
 
 ## CSS/SCSS Guidelines
-- Uses bootstrap v5.3.3
-- Use bootstrap components and utilities
-- The shipped stylesheet lives in `assets/css/shine.css` - DO NOT edit directly.
-- Modify the SCSS sources in `assets/scss/`, and use sass to regenerate `shine.css` file
-- Keep the layout responsive and mobile-friendly; test at multiple viewport widths when you adjust styling.
+- Styling is based on Bootstrap 5.3.3 and the Shine theme.
+- Modify the SCSS sources in `assets/scss/` and recompile `assets/css/shine.css` with Sass; never edit the compiled CSS directly.
+- Ensure the layout remains responsive—spot-check changes on small and large viewports.
 
 ## JavaScript Guidelines
-- All behaviour is implemented with vanilla JS in `assets/js/i18n.js`. Extend it using the same style (modular functions, early returns for null checks, no transpilation-only syntax).
-- Avoid introducing global variables unless they are needed by the HTML; prefer module-scoped helpers.
-- Maintain graceful error handling for network operations (language file fetches, etc.).
+- Behaviour is implemented with vanilla ES modules in `assets/js/`. Follow the existing modular style and avoid adding global variables unless necessary.
+- Do not introduce transpilation-only syntax or new build tooling.
 
-## Localization Content
-- Language data lives in `assets/lang/*.json`. When you add or edit content, keep keys consistent across all language files.
-- Ensure each language file includes the metadata section used for `<title>` and `<meta>` tags so they remain localized.
+## Localisation Content
+- Keep localisation keys consistent across every file in `assets/lang/`.
+- Ensure each language includes the metadata required for the `<head>` section so titles and descriptions stay localised.
 
 ## Assets
-- Place new static assets under `assets/images/` and reference them with relative paths.
-- Compress large images before committing to keep the repository lightweight.
+- Place new static assets under `assets/images/` and compress large files before committing.
+- Reference assets with relative paths that work when hosted from the repository root.
 
-## Testing & Preview
-- There are no automated tests. Manually preview the site by serving the repository via a simple static server (for example, `python3 -m http.server`) and inspecting it in a browser.
+## Testing, Linting & Preview
+- Unit tests live under `tests/` and guard the build pipeline. Run `pnpm test` after changing the template, build script, config, or localisation data.
+- Run `pnpm lint:fix` whenever you touch JavaScript or HTML to keep formatting and lint rules satisfied.
+- Preview the site with a simple static server such as `python3 -m http.server` before shipping visual changes.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,37 @@
 # Patrick Nüser – Resume Website
 
 ## Overview
-This repository contains the source of Patrick Nüser's online CV, a fully static single-page site that renders resume content dynamically at runtime. The page is powered by Bootstrap 5 styling, Bootstrap Icons, and a bundled Font Awesome script, and it loads its main stylesheet (`assets/css/shine.css`) and behaviour script (`assets/js/i18n.js`) directly from the `index.html` entry point.
+This repository contains the source for Patrick Nüser's online CV. The site is built as a static bundle that can be hosted on Githu
+b Pages or any other static host. All resume content lives in language-specific JSON files and is compiled into ready-to-serve `in
+dex.html` builds through a lightweight Node-based generator.
+
+Running `pnpm build` renders the Mustache template in `templates/resume.mustache` against the localisation data defined in `assets
+/lang/*.json` and the locale configuration in `build.config.json`. The command emits language-specific HTML files (English and Germ
+an by default) directly into the repository root so the output can be published without any runtime JavaScript.
 
 ## Tech stack & architecture
-- **Static HTML shell** – `index.html` provides the structural markup for the resume sections (profile, experience, skills, projects, education, languages, interests) and wires up external assets such as Google Fonts, Bootstrap Icons, Font Awesome, and the theme CSS.
-- **Data-driven localisation** – `assets/js/i18n.js` fetches language JSON files, caches them, and fills the DOM on load, allowing the same markup to render multiple languages while persisting the visitor's preferred choice via `localStorage`.
-- **Content sources** – Language-specific resume data lives in `assets/lang/en.json` and `assets/lang/de.json`, covering metadata, summary text, timeline entries, skills, and more.
-- **Styling** – The published CSS is compiled from the SCSS entry point `assets/scss/shine.scss`, which defines the colour palette, overrides Bootstrap variables, and imports the Shine theme partials.
+- **Static HTML builds** – The résumé is rendered ahead of time; no client-side JavaScript is required to populate the page.
+- **Mustache templating** – `templates/resume.mustache` defines the shared document structure. It is rendered for each locale with
+the help of [`mustache`](https://github.com/janl/mustache.js).
+- **Build script** – `scripts/build.mjs` loads `build.config.json`, pulls in the language JSON files, and writes the final `index.
+html` and `index.de.html` files. The script validates the configuration, computes helper data (e.g. language proficiency bars), a
+nd keeps the output consistently formatted with two-space indentation.
+- **Localisation content** – `assets/lang/en.json` and `assets/lang/de.json` provide all résumé copy, including metadata, contact i
+nformation, experience, skills, and more.
+- **Styling** – The published CSS at `assets/css/shine.css` is compiled from the SCSS entry point `assets/scss/shine.scss`, which c
+ustomises Bootstrap 5 and the Shine theme. No changes to the Sass workflow are required for the static build.
+- **Assets** – Profile imagery and icons are stored under `assets/images/`, while fonts and icons are loaded from their respective
+CDNs.
 
 ## Project structure
 ```
-index.html                # Static shell that loads assets and defines resume sections
+build.config.json         # Locale and asset configuration for the build script
+index.html                # English resume (generated)
+index.de.html             # German resume (generated)
+scripts/build.mjs         # Node build script that renders the Mustache template
+templates/resume.mustache # Shared HTML template rendered for each locale
 assets/
   css/shine.css           # Compiled theme stylesheet
-  js/i18n.js              # Language loader and DOM renderer
   lang/en.json            # English resume content
   lang/de.json            # German resume content
   images/                 # Profile photo used in the header
@@ -23,42 +40,64 @@ favicon.ico               # Browser tab icon
 ```
 
 ## Getting started locally
-Because the resume data is fetched with `window.fetch`, the page must be served over HTTP(S). Opening `index.html` directly from the file system will be blocked by most browsers.
-
-1. Ensure you have a static file server available (e.g. Python 3).
-2. From the repository root, start a local server:
+1. Install dependencies (once per checkout):
+   ```bash
+   pnpm install
+   ```
+2. Regenerate the language-specific HTML files:
+   ```bash
+   pnpm build
+   ```
+3. Serve the repository via any static web server:
    ```bash
    python3 -m http.server 8000
    ```
-3. Visit [http://localhost:8000](http://localhost:8000) in your browser to see the site.
+4. Visit [http://localhost:8000](http://localhost:8000) in your browser to preview the résumé pages.
 
-Any simple HTTP server (Node's `http-server`, Ruby's `webrick`, etc.) will work equally well.
+The generated HTML files are committed, so rerun the build whenever you change the template, localisation JSON, build configuration, or the build script to keep `index.html` and `index.de.html` synchronised.
 
 ## Updating resume content
-1. Choose the language file you want to edit in `assets/lang/`.
-2. Update the relevant sections:
-   - `meta`: document title, meta description, and HTML `lang` attribute.
-   - `topBar`, `header`, `summary`, `experience`, `additionalExperience`, `techStack`, `softSkills`, `projects`, `education`, `languages`, `interests`: each section maps directly to the markup defined in `index.html` and is rendered by `i18n.js`.
-3. Save the file and refresh your browser. The changes appear immediately because the content is rendered client-side.
+1. Edit the appropriate language file under `assets/lang/` (e.g. `en.json` or `de.json`).
+2. Ensure any new keys are added consistently across all language files.
+3. Run `pnpm build` to regenerate `index.html` and `index.de.html`.
+4. Preview the changes in a browser by serving the repository, as described above.
 
-The profile photo displayed in the header lives at `assets/images/patrick-nüser.256x256.jpg`; replace this file to update the image without changing the markup.
+The profile photo displayed in the header lives at `assets/images/patrick-nüser.256x256.jpg`. Replacing this file updates the imag
+e without modifying the template or localisation data.
 
 ## Adding another language
 1. Duplicate an existing JSON file in `assets/lang/` and translate its values.
-2. Register the new file inside `LANGUAGE_FILES` near the top of `assets/js/i18n.js` and add it to the language selector options in each language JSON so it appears in the dropdown.
-3. Optionally set a new default by updating `currentLanguage` in `i18n.js`.
+2. Add a new entry to the `locales` array in `build.config.json`, specifying the locale code, source JSON path, and desired output
+filename.
+3. Update the `languageSelector.options` array in every language JSON file so the new locale appears in the language switcher.
+4. Run `pnpm build` to generate the additional HTML file.
 
-The loader caches responses and falls back to English if a fetch fails, so additional languages integrate smoothly.
+After updating locales, run `pnpm test` to ensure the generated markup still includes the required résumé sections and language links.
+
+## Build configuration
+`build.config.json` controls the build script:
+- `template`: Path to the Mustache template file.
+- `defaultLocale`: Locale used for the `x-default` alternate link.
+- `assets.profileImage`: Path to the profile image referenced in the header.
+- `locales`: Array describing each locale with `locale` (identifier), `source` (path to the JSON data), and `output` (HTML file na
+me).
+
+Adjust these values to change asset references or add/remove languages.
 
 ## Styling and theming
-- Adjust colour tokens or Bootstrap overrides in `assets/scss/shine.scss`, then recompile the CSS using the Sass CLI:
+- Modify colour tokens or Bootstrap overrides in `assets/scss/shine.scss`, then recompile the CSS using the Sass CLI:
   ```bash
   sass assets/scss/shine.scss assets/css/shine.css --style=compressed
   ```
-- The SCSS entry point imports a full copy of Bootstrap's source and Shine theme partials, allowing fine-grained customisation while keeping the template look and feel.
+- The SCSS entry point imports Bootstrap's source and Shine theme partials, allowing fine-grained customisation while keeping the
+template look and feel.
 
 ## Deployment
-The site is a static bundle, so you can deploy it to any static host (GitHub Pages, Netlify, Vercel, S3, etc.). Upload the repository contents (or the `index.html` and `assets` directory) and ensure the host serves them over HTTPS for best compatibility with the fetch-based localisation.
+The site is a static bundle. Publish the repository contents—including the generated `index.html` files and the `assets` directory—to any static host (GitHub Pages, Netlify, Vercel, S3, etc.). No additional build step is required on the server.
+
+## Testing & linting
+- `pnpm test` executes the Node test suite in `tests/`, verifying that the build pipeline keeps critical résumé sections and language cross-links intact.
+- `pnpm lint:fix` runs ESLint over `assets/js/` and HTMLHint over the generated pages to automatically address formatting and lint issues.
 
 ## Credits & licensing
-This resume builds on the “Shine” Bootstrap 5 template by Xiaoying Riley / 3rd Wave Media, which requires retaining the attribution link in the footer when used for free distributions.
+This résumé builds on the “Shine” Bootstrap 5 template by Xiaoying Riley / 3rd Wave Media, which requires retaining the attribution link in the footer when used for free distributions.

--- a/build.config.json
+++ b/build.config.json
@@ -1,0 +1,19 @@
+{
+  "template": "templates/resume.mustache",
+  "defaultLocale": "en",
+  "assets": {
+    "profileImage": "assets/images/patrick-nüser.256x256.jpg"
+  },
+  "locales": [
+    {
+      "locale": "en",
+      "source": "assets/lang/en.json",
+      "output": "index.html"
+    },
+    {
+      "locale": "de",
+      "source": "assets/lang/de.json",
+      "output": "index.de.html"
+    }
+  ]
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,16 @@
+import globals from "globals";
+
+export default [
+  {
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "script",
+      globals: {
+        ...globals.browser
+      }
+    },
+    rules: {
+      "no-console": "off"
+    }
+  }
+];

--- a/index.de.html
+++ b/index.de.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="de">
   <head>
     <title>Patrick Nüser – Senior Software Engineer</title>
 
@@ -7,7 +7,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Resume of Patrick Nüser, Senior Software Engineer from Hamburg.">
+    <meta name="description" content="Lebenslauf von Patrick Nüser, Senior Software Engineer aus Hamburg.">
     <meta name="author" content="Xiaoying Riley at 3rd Wave Media">
     <link rel="shortcut icon" href="favicon.ico">
 
@@ -35,22 +35,22 @@
           <div class="resume-wrapper mx-auto rounded-2">
             <div class="resume-actions d-flex flex-column flex-sm-row align-items-center justify-content-center justify-content-sm-end gap-3 w-100 px-4 px-lg-5 pt-4 d-print-none">
               <div class="language-switcher d-flex flex-column flex-sm-row align-items-center justify-content-center justify-content-sm-end gap-2">
-                <span class="text-uppercase small fw-semibold">Language</span>
-                <div class="btn-group btn-group-sm" role="group" aria-label="Select language">
-                  <a class="btn btn-outline-secondary btn-sm active" href="index.html" lang="en" hreflang="en" aria-current="page">EN</a>
-                  <a class="btn btn-outline-secondary btn-sm" href="index.de.html" lang="de" hreflang="de">DE</a>
+                <span class="text-uppercase small fw-semibold">Sprache</span>
+                <div class="btn-group btn-group-sm" role="group" aria-label="Sprache auswählen">
+                  <a class="btn btn-outline-secondary btn-sm" href="index.html" lang="en" hreflang="en">EN</a>
+                  <a class="btn btn-outline-secondary btn-sm active" href="index.de.html" lang="de" hreflang="de" aria-current="page">DE</a>
                 </div>
               </div>
-              <a class="btn btn-primary" href="mailto:mail@patrick-nueser.de">Contact</a>
+              <a class="btn btn-primary" href="mailto:mail@patrick-nueser.de">Kontakt</a>
             </div>
             <div class="resume-header px-4 px-lg-5 py-4 py-lg-5">
               <div class="resume-profile-holder text-center text-md-start d-flex flex-column flex-md-row align-items-center align-items-md-start gap-4 gap-lg-5">
                 <div class="flex-shrink-0">
-                  <img class="resume-profile-pic rounded-circle" src="assets/images/patrick-nüser.256x256.jpg" alt="Portrait of Patrick Nüser">
+                  <img class="resume-profile-pic rounded-circle" src="assets/images/patrick-nüser.256x256.jpg" alt="Porträt von Patrick Nüser">
                 </div>
                 <div class="flex-grow-1 w-100">
                   <h2 class="resume-name text-uppercase mb-2 mb-lg-3">Patrick Nüser</h2>
-                  <div class="resume-role-title text-uppercase">Senior Software Engineer · Team/Tech Lead · Cloud &amp; AI Solutions</div>
+                  <div class="resume-role-title text-uppercase">Senior Software Engineer · Team-/Tech-Lead · Cloud &amp; AI Solutions</div>
                   <div class="resume-contact mt-4 mt-md-3">
                     <ul class="resume-contact-list row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-3 list-unstyled mb-0">
                       <li class="col d-flex align-items-center gap-2 text-break">
@@ -63,7 +63,7 @@
                       </li>
                       <li class="col d-flex align-items-center gap-2 text-break">
                         <i class="resume-contact-icon bi bi-geo-alt flex-shrink-0"></i>
-                        <span>Hamburg, Germany</span>
+                        <span>Hamburg, Deutschland</span>
                       </li>
                     </ul>
                   </div>
@@ -75,32 +75,32 @@
               <div class="row g-4 g-lg-5">
                 <div class="col-main col-12 col-lg-8 pe-lg-4">
                   <section class="resume-summary-section resume-section">
-                    <h3 class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-person me-2"></i>Profile</h3>
+                    <h3 class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-person me-2"></i>Profil</h3>
                     <div class="resume-summary-desc">
-                      <p>I&#39;m Patrick, a software engineer from Hamburg. Complex problems motivate me, exciting projects drive me. Thanks to my analytical mindset I recognize and solve challenges quickly and in a structured way. Especially in teams my communication skills shine – I work constructively, solution-oriented and with a clear view of cost and benefit.</p>
-                      <p>My sports background taught me discipline and resilience: sticking with it when things get tough and staying calm when the situation allows. New technologies excite me – I continuously develop both professionally and personally.</p>
+                      <p>Ich bin Patrick, ein Software Engineer aus Hamburg. Komplexe Probleme motivieren mich, spannende Projekte treiben mich an. Dank meiner analytischen Denkweise erkenne und löse ich Herausforderungen schnell und strukturiert. Besonders im Team kommen meine kommunikativen Fähigkeiten zur Geltung – ich arbeite konstruktiv, lösungsorientiert und mit einem klaren Blick für Kosten und Nutzen.</p>
+                      <p>Durch meinen sportlichen Hintergrund habe ich Disziplin und Resilienz gelernt: dranzubleiben, wenn es hart wird, und Gelassenheit zu bewahren, wenn es die Situation erlaubt. Neue Technologien begeistern mich – ich entwickle mich fachlich wie persönlich stetig weiter.</p>
                     </div>
                   </section>
 
                   <hr>
 
                   <section class="resume-experience-section resume-section">
-                    <h3 class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-briefcase me-2"></i>Professional Experience</h3>
+                    <h3 class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-briefcase me-2"></i>Berufserfahrung</h3>
                     <div class="resume-timeline position-relative">
                       <article class="resume-timeline-item position-relative pb-5">
                         <div class="resume-timeline-item-header mb-2">
                           <div class="resume-position-meta d-flex justify-content-between mb-1">
-                            <div class="resume-position-time">09/2024 – present</div>
+                            <div class="resume-position-time">09/2024 – heute</div>
                             <div class="resume-company-name">1Komma5° Heartbeat GmbH · Hamburg</div>
                           </div>
-                          <h3 class="resume-position-title mb-1">Senior Software Engineer</h3>
+                          <h3 class="resume-position-title mb-1">Senior Softwareentwickler</h3>
                         </div>
                         <div class="resume-timeline-item-desc">
                           <ul class="resume-timeline-list">
-                            <li>Lead qualification service: technical project leadership &amp; system design → ~10 minutes saved per lead, validated/standardized data capture for reporting &amp; downstream systems.</li>
-                            <li>Architecture: designed ADRs for workflow engines &amp; Zoho CRM → standardized &amp; scalable CRM integrations.</li>
-                            <li>Mentoring: regular pairing sessions; sharing patterns &amp; principles → capability building within the team.</li>
-                            <li>AI/LLM: co-shaped the LLM working group → established standards for LLM-assisted development.</li>
+                            <li>Lead-Qualifizierungs-Service: Technische Projektleitung &amp; Systemdesign → ~10 Min. Zeitersparnis pro Lead, validierte/standardisierte Datenerfassung für Reporting &amp; Downstream-Systeme.</li>
+                            <li>Architektur: ADR für Workflow Engines &amp; Zoho CRM konzipiert → Standardisierung &amp; Skalierbarkeit von CRM-Integrationen.</li>
+                            <li>Mentoring: Regelmäßige Pairing-Sessions; Vermittlung von Patterns &amp; Principles → Skill-Aufbau im Team.</li>
+                            <li>AI/LLM: Mitgestaltung der LLM-Arbeitsgruppe → Standards für LLM-gestützte Entwicklung etabliert.</li>
                           </ul>
                         </div>
                       </article>
@@ -110,15 +110,15 @@
                             <div class="resume-position-time">03/2022 – 07/2024</div>
                             <div class="resume-company-name">Njiuko GmbH · Hamburg</div>
                           </div>
-                          <h3 class="resume-position-title mb-1">Software Engineer, Team/Tech Lead</h3>
+                          <h3 class="resume-position-title mb-1">Softwareentwickler, Team-/Tech-Lead</h3>
                         </div>
                         <div class="resume-timeline-item-desc">
                           <ul class="resume-timeline-list">
-                            <li>Leadership: managed 8 engineers (disciplinary &amp; functional: salary reviews, development plans, OKRs, recruiting, offboarding).</li>
-                            <li>Efficiency: standardized HubSpot development via workflow engines → integration projects up to 50% faster.</li>
-                            <li>Tech transformation: actively shaped the shift from Ruby on Rails to TypeScript.</li>
-                            <li>Talent development: retrained mobile engineers to web → higher utilization &amp; skill diversity.</li>
-                            <li>Business impact: won/retained major accounts (incl. Gruner &amp; Jahr, Ysolutions); budget ownership, proposals, technical evaluations.</li>
+                            <li>Führung: Leitung von 8 Engineers (fachlich &amp; disziplinarisch: Gehaltsgespräche, Entwicklungspläne, OKRs, Recruiting, Offboarding).</li>
+                            <li>Effizienz: Standardisierung der HubSpot-Entwicklung via Workflow Engines → Integrationsprojekte bis zu 50 % schneller.</li>
+                            <li>Tech-Transformation: Stack-Wandel von Ruby on Rails zu TypeScript aktiv mitgestaltet.</li>
+                            <li>Talententwicklung: Umschulung von Mobile- zu Web-Entwicklern → bessere Auslastung &amp; Skill-Diversität.</li>
+                            <li>Business Impact: Große Aufträge gewonnen/gesichert (u. a. Gruner &amp; Jahr, Ysolutions); Budgetverantwortung, Angebote, technische Evaluationen.</li>
                           </ul>
                         </div>
                       </article>
@@ -128,13 +128,13 @@
                             <div class="resume-position-time">01/2019 – 03/2022</div>
                             <div class="resume-company-name">tourrise GmbH · Hamburg</div>
                           </div>
-                          <h3 class="resume-position-title mb-1">Technical Co-Founder (CTO)</h3>
+                          <h3 class="resume-position-title mb-1">Technischer Mitgründer (CTO)</h3>
                         </div>
                         <div class="resume-timeline-item-desc">
                           <ul class="resume-timeline-list">
-                            <li>Product build: architecture &amp; implementation of the initial infrastructure (multi-tenancy, payments, front-/mid-/back office).</li>
-                            <li>Integrations: interfaces to flight providers, invoicing, accounting.</li>
-                            <li>Impact: 2 paying customers (~€200k ARR) → established product in the market.</li>
+                            <li>Produktaufbau: Architektur &amp; Umsetzung der initialen Infrastruktur (Mandantenfähigkeit, Payment, Front-/Mid-/Backoffice).</li>
+                            <li>Integrationen: Schnittstellen zu Flugdienstleistern, Rechnungsstellung, Buchhaltung.</li>
+                            <li>Impact: 2 zahlende Kunden (~200 k ARR) → Produkt im Markt etabliert.</li>
                             <li>Tech: Ruby on Rails, Docker, Kamal.</li>
                           </ul>
                         </div>
@@ -143,17 +143,17 @@
                         <div class="resume-timeline-item-header mb-2">
                           <div class="resume-position-meta d-flex justify-content-between mb-1">
                             <div class="resume-position-time">03/2017 – 07/2022</div>
-                            <div class="resume-company-name">Self-employed · Remote/Hamburg</div>
+                            <div class="resume-company-name">Selbstständig · Remote/Hamburg</div>
                           </div>
-                          <h3 class="resume-position-title mb-1">Full-Stack Engineer &amp; Consultant</h3>
+                          <h3 class="resume-position-title mb-1">Full-Stack Entwickler &amp; Berater</h3>
                         </div>
                         <div class="resume-timeline-item-desc">
                           <ul class="resume-timeline-list">
-                            <li>OMR: co-planned the reviews product; implemented core infrastructure.</li>
-                            <li>Peek &amp; Cloppenburg: modernized corporate sites → Next.js + headless CMS.</li>
-                            <li>XING: co-designed &amp; built GDPR infrastructure in the Startpage team.</li>
-                            <li>A.W. Niemeyer: Shopify migration, Liquid templates &amp; custom apps; modernized ERP for real-time availability.</li>
-                            <li>Other projects: technical architecture/planning &amp; strategic consulting (SMB/enterprise).</li>
+                            <li>OMR: Reviews-Produkt mitgeplant; Kerninfrastruktur implementiert.</li>
+                            <li>Peek &amp; Cloppenburg: Corporate-Sites modernisiert → Next.js + Headless CMS.</li>
+                            <li>XING: GDPR-Infrastruktur im „Startpage“-Team mitkonzipiert &amp; entwickelt.</li>
+                            <li>A.W. Niemeyer: Shopify-Umzug, Liquid Templates &amp; Custom Apps; ERP-Modernisierung für Echtzeit-Verfügbarkeiten.</li>
+                            <li>Weitere Projekte: Technische Architektur/Planung &amp; strategische Beratung (KMU/Enterprise).</li>
                           </ul>
                         </div>
                       </article>
@@ -163,12 +163,12 @@
                             <div class="resume-position-time">06/2014 – 03/2017</div>
                             <div class="resume-company-name">Njiuko GmbH · Hamburg</div>
                           </div>
-                          <h3 class="resume-position-title mb-1">Backend Engineer</h3>
+                          <h3 class="resume-position-title mb-1">Backend Entwickler</h3>
                         </div>
                         <div class="resume-timeline-item-desc">
                           <ul class="resume-timeline-list">
-                            <li>Built new &amp; existing platforms (Protonet SOUL, Lagardère Sports Keeper, Protonet Leads App).</li>
-                            <li>DevOps &amp; operations for highly available systems; code reviews &amp; pair programming.</li>
+                            <li>Entwicklung neuer und bestehender Plattformen (Protonet SOUL, Lagardère Sports Keeper, Protonet Leads App).</li>
+                            <li>DevOps &amp; Betrieb hochverfügbarer Systeme; Code Reviews &amp; Pair Programming.</li>
                           </ul>
                         </div>
                       </article>
@@ -178,15 +178,15 @@
                   <hr>
 
                   <section class="resume-section">
-                    <h3 class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-collection me-2"></i>Additional experience (selected)</h3>
+                    <h3 class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-collection me-2"></i>Weitere Erfahrungen (Auswahl)</h3>
                     <ul class="list-unstyled mb-0">
-                      <li><strong>Freelance (2012–2014)</strong>: Booking system (inventory, roles, REST, Easybill/Flightstats); road cycling map Fuerteventura (with Hannes Hawaii Tours, Adobe Suite).</li>
-                      <li><strong>Hannes Hawaii Tours (2009–2014)</strong>: Tour guide &amp; travel lead, groups up to 120 people, team coordination.</li>
-                      <li><strong>Jack Wolfskin (2010–2012)</strong>: Sold functional textiles &amp; accessories.</li>
-                      <li><strong>SCOL Ski Trips (2006–2008)</strong>: Led youth &amp; family groups (seasonal).</li>
-                      <li><strong>Sport Reckemeier (2006–2008)</strong>: Specialist running shoe sales; deputized store management, annual ordering.</li>
-                      <li><strong>Etzhorner Krug (2004–2006)</strong>: Dishwasher (first job).</li>
-                      <li><strong>Civil service (08/2007 – 06/2008)</strong>: State Education Center for the Hearing Impaired, Oldenburg.</li>
+                      <li><strong>Selbstständig (2012–2014)</strong>: Buchungssystem (Kontingente, Rollen, REST, Easybill-/Flightstats); Radsportkarte Fuerteventura (mit Hannes Hawaii Tours, Adobe Suite).</li>
+                      <li><strong>Hannes Hawaii Tours (2009–2014)</strong>: Tourguide &amp; Reiseleiter, Gruppen bis 120 Personen, Teamkoordination.</li>
+                      <li><strong>Jack Wolfskin (2010–2012)</strong>: Verkauf von Funktionstextilien &amp; Zubehör.</li>
+                      <li><strong>SCOL Skireisen (2006–2008)</strong>: Leitung von Jugend- &amp; Familiengruppen (Saison).</li>
+                      <li><strong>Sport Reckemeier (2006–2008)</strong>: Laufschuhfachverkäufer; Vertretung Geschäftsführung, Jahresorder.</li>
+                      <li><strong>Etzhorner Krug (2004–2006)</strong>: Tellerwäscher (erster Job).</li>
+                      <li><strong>Zivildienst (08/2007 – 06/2008)</strong>: Landesbildungszentrum für Hörgeschädigte, Oldenburg.</li>
                     </ul>
                   </section>
                 </div>
@@ -195,7 +195,7 @@
                     <h3 class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-gear me-2"></i>Tech Stack</h3>
                     <ul class="list-unstyled">
                       <li class="mb-3">
-                        <div class="resume-skill-name">Languages &amp; Frameworks</div>
+                        <div class="resume-skill-name">Sprachen &amp; Frameworks</div>
                         <div class="d-flex flex-wrap gap-2 mt-2">
                           <span class="badge resume-skill-badge">Ruby &amp; Ruby on Rails</span>
                           <span class="badge resume-skill-badge">TypeScript, Node.js &amp; NestJS</span>
@@ -203,39 +203,39 @@
                         </div>
                       </li>
                       <li class="mb-3">
-                        <div class="resume-skill-name">Cloud &amp; Operations</div>
+                        <div class="resume-skill-name">Cloud &amp; Betrieb</div>
                         <div class="d-flex flex-wrap gap-2 mt-2">
                           <span class="badge resume-skill-badge">AWS, Azure &amp; GCP</span>
                           <span class="badge resume-skill-badge">Docker &amp; Kamal</span>
                         </div>
                       </li>
                       <li class="mb-3">
-                        <div class="resume-skill-name">Data &amp; Storage</div>
+                        <div class="resume-skill-name">Daten &amp; Speicher</div>
                         <div class="d-flex flex-wrap gap-2 mt-2">
                           <span class="badge resume-skill-badge">Postgres &amp; MySQL</span>
                           <span class="badge resume-skill-badge">Redis &amp; Elasticsearch</span>
                         </div>
                       </li>
                       <li class="mb-3">
-                        <div class="resume-skill-name">CRM &amp; Automation</div>
+                        <div class="resume-skill-name">CRM &amp; Automatisierung</div>
                         <div class="d-flex flex-wrap gap-2 mt-2">
                           <span class="badge resume-skill-badge">Zoho CRM</span>
                           <span class="badge resume-skill-badge">HubSpot</span>
-                          <span class="badge resume-skill-badge">Workflow engines &amp; integrations</span>
+                          <span class="badge resume-skill-badge">Workflow Engines &amp; Integrationen</span>
                         </div>
                       </li>
                       <li class="mb-3">
-                        <div class="resume-skill-name">Commerce &amp; Content</div>
+                        <div class="resume-skill-name">Commerce &amp; Content-Plattformen</div>
                         <div class="d-flex flex-wrap gap-2 mt-2">
                           <span class="badge resume-skill-badge">Shopify &amp; Liquid</span>
-                          <span class="badge resume-skill-badge">Headless CMS architectures</span>
+                          <span class="badge resume-skill-badge">Headless-CMS-Architekturen</span>
                         </div>
                       </li>
                       <li>
-                        <div class="resume-skill-name">AI &amp; Enablement</div>
+                        <div class="resume-skill-name">KI &amp; Enablement</div>
                         <div class="d-flex flex-wrap gap-2 mt-2">
-                          <span class="badge resume-skill-badge">LLM-assisted development</span>
-                          <span class="badge resume-skill-badge">AI experimentation &amp; prototyping</span>
+                          <span class="badge resume-skill-badge">LLM-gestützte Entwicklung</span>
+                          <span class="badge resume-skill-badge">KI-Experimente &amp; Prototyping</span>
                         </div>
                       </li>
                     </ul>
@@ -246,53 +246,53 @@
                   <section class="resume-skills-section resume-section">
                     <h3 class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-person-gear me-2"></i>Soft Skills</h3>
                     <ul class="list-inline">
-                      <li class="list-inline-item"><span class="badge resume-skill-badge">Team leadership &amp; coaching</span></li>
-                      <li class="list-inline-item"><span class="badge resume-skill-badge">Architecture &amp; system design</span></li>
-                      <li class="list-inline-item"><span class="badge resume-skill-badge">Stakeholder management</span></li>
-                      <li class="list-inline-item"><span class="badge resume-skill-badge">Product focus &amp; cost-benefit</span></li>
-                      <li class="list-inline-item"><span class="badge resume-skill-badge">Mentoring &amp; pairing</span></li>
-                      <li class="list-inline-item"><span class="badge resume-skill-badge">Code quality &amp; reviews</span></li>
+                      <li class="list-inline-item"><span class="badge resume-skill-badge">Teamführung &amp; Coaching</span></li>
+                      <li class="list-inline-item"><span class="badge resume-skill-badge">Architektur &amp; Systemdesign</span></li>
+                      <li class="list-inline-item"><span class="badge resume-skill-badge">Stakeholder-Management</span></li>
+                      <li class="list-inline-item"><span class="badge resume-skill-badge">Produktfokus &amp; Kosten-Nutzen</span></li>
+                      <li class="list-inline-item"><span class="badge resume-skill-badge">Mentoring &amp; Pairing</span></li>
+                      <li class="list-inline-item"><span class="badge resume-skill-badge">Code-Quality &amp; Reviews</span></li>
                     </ul>
                   </section>
 
                   <hr>
 
                   <section class="resume-section">
-                    <h3 class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-collection-play me-2"></i>Projects (selected)</h3>
+                    <h3 class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-collection-play me-2"></i>Projekte (Auswahl)</h3>
                     <div class="item">
                       <h4 class="item-heading"><i class="item-icon bi bi-square-fill me-2"></i>OMR – Reviews</h4>
-                      <div class="item-desc">Co-planned the reviews product and implemented core components of the scalable architecture.</div>
+                      <div class="item-desc">Reviews-Produkt mitgeplant und Kernkomponenten der skalierbaren Architektur implementiert.</div>
                     </div>
                     <div class="item">
                       <h4 class="item-heading"><i class="item-icon bi bi-square-fill me-2"></i>Peek &amp; Cloppenburg – Corporate Sites</h4>
-                      <div class="item-desc">Modernized corporate websites: Next.js + headless CMS for better performance &amp; more efficient workflows.</div>
+                      <div class="item-desc">Corporate-Websites modernisiert: Next.js + Headless CMS für bessere Performance &amp; effizientere Workflows.</div>
                     </div>
                     <div class="item">
-                      <h4 class="item-heading"><i class="item-icon bi bi-square-fill me-2"></i>XING – GDPR Infrastructure</h4>
-                      <div class="item-desc">Co-designed and built compliance-ready systems in the Startpage team with focus on stability &amp; maintainability.</div>
+                      <h4 class="item-heading"><i class="item-icon bi bi-square-fill me-2"></i>XING – GDPR-Infrastruktur</h4>
+                      <div class="item-desc">Compliance-fähige Systeme im „Startpage“-Team mitkonzipiert und entwickelt, Fokus auf Stabilität &amp; Wartbarkeit.</div>
                     </div>
                     <div class="item">
                       <h4 class="item-heading"><i class="item-icon bi bi-square-fill me-2"></i>A.W. Niemeyer – Shopify &amp; ERP</h4>
-                      <div class="item-desc">Shopify migration including custom apps; modernized ERP for real-time availability in retail.</div>
+                      <div class="item-desc">Shopify-Migration inkl. Custom Apps; ERP-Modernisierung für Echtzeit-Verfügbarkeiten im Handel.</div>
                     </div>
                   </section>
 
                   <hr>
 
                   <section class="resume-educate-section resume-section">
-                    <h3 class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-book me-2"></i>Education</h3>
+                    <h3 class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-book me-2"></i>Ausbildung</h3>
                     <ul class="list-unstyled">
                       <li class="mb-2">
-                        <div class="resume-degree font-weight-bold">B.Sc. Computer Science</div>
-                        <div class="resume-degree-org">University of Osnabrück</div>
-                        <div class="resume-degree-time">Graduated 12/2013</div>
-                        <div class="resume-degree-desc">Thesis: Developed a live streaming &amp; VOD component for an online back training studio. Tutorials: Software Engineering (04–07/2013); Equation-based Models I (04–07/2012).</div>
+                        <div class="resume-degree font-weight-bold">B.Sc. Informatik</div>
+                        <div class="resume-degree-org">Universität Osnabrück</div>
+                        <div class="resume-degree-time">Abschluss 12/2013</div>
+                        <div class="resume-degree-desc">Abschlussarbeit: Entwicklung einer Livestreaming- &amp; VOD-Komponente für ein Online-Rückenstudio. Tutorien: Software Engineering (04–07/2013); Gleichungsbasierte Modelle I (04–07/2012).</div>
                       </li>
                       <li>
-                        <div class="resume-degree font-weight-bold">Study abroad – Computer Science</div>
-                        <div class="resume-degree-org">University of Stockholm</div>
+                        <div class="resume-degree font-weight-bold">Auslandssemester Informatik</div>
+                        <div class="resume-degree-org">Universität Stockholm</div>
                         <div class="resume-degree-time">08/2012 – 02/2013</div>
-                        <div class="resume-degree-desc">Focus areas: data mining, network security, computer security.</div>
+                        <div class="resume-degree-desc">Schwerpunkte: Data Mining, Network Security, Computer Security.</div>
                       </li>
                     </ul>
                   </section>
@@ -300,10 +300,10 @@
                   <hr>
 
                   <section class="resume-lang-section resume-section">
-                    <h3 class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-translate me-2"></i>Languages</h3>
+                    <h3 class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-translate me-2"></i>Sprachen</h3>
                     <ul class="list-unstyled resume-lang-list">
                       <li class="mb-2">
-                        <div class="resume-lang-name">German (native)</div>
+                        <div class="resume-lang-name">Deutsch (Muttersprache)</div>
                         <div class="resume-level-indicator row gx-0 flex-nowrap">
                           <div class="col"><span class="item item-full"></span></div>
                           <div class="col"><span class="item item-full"></span></div>
@@ -318,7 +318,7 @@
                         </div>
                       </li>
                       <li>
-                        <div class="resume-lang-name">English (fluent)</div>
+                        <div class="resume-lang-name">Englisch (fließend)</div>
                         <div class="resume-level-indicator row gx-0 flex-nowrap">
                           <div class="col"><span class="item item-full"></span></div>
                           <div class="col"><span class="item item-full"></span></div>
@@ -338,11 +338,11 @@
                   <hr>
 
                   <section class="resume-interests-section resume-section">
-                    <h3 class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-sun me-2"></i>Interests</h3>
+                    <h3 class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-sun me-2"></i>Interessen</h3>
                     <ul class="list-inline">
-                      <li class="list-inline-item"><span class="badge resume-skill-badge">Competitive endurance sports (triathlon, running, road cycling)</span></li>
-                      <li class="list-inline-item"><span class="badge resume-skill-badge">Cooking &amp; food</span></li>
-                      <li class="list-inline-item"><span class="badge resume-skill-badge">Tech &amp; games</span></li>
+                      <li class="list-inline-item"><span class="badge resume-skill-badge">Langjähriger Leistungssport (Triathlon, Laufen, Rennrad)</span></li>
+                      <li class="list-inline-item"><span class="badge resume-skill-badge">Kochen &amp; Essen</span></li>
+                      <li class="list-inline-item"><span class="badge resume-skill-badge">Tech &amp; Games</span></li>
                     </ul>
                   </section>
                 </div>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "cv",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "node scripts/build.mjs",
+    "lint:fix": "eslint --fix assets/js && htmlhint index.html index.de.html",
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@10.13.1",
+  "devDependencies": {
+    "eslint": "^9.36.0",
+    "globals": "^16.4.0",
+    "htmlhint": "^1.7.1",
+    "mustache": "^4.2.0"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,824 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      eslint:
+        specifier: ^9.36.0
+        version: 9.36.0
+      globals:
+        specifier: ^16.4.0
+        version: 16.4.0
+      htmlhint:
+        specifier: ^1.7.1
+        version: 1.7.1
+      mustache:
+        specifier: ^4.2.0
+        version: 4.2.0
+
+packages:
+
+  '@eslint-community/eslint-utils@4.9.0':
+    resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.1':
+    resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.21.0':
+    resolution: {integrity: sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.3.1':
+    resolution: {integrity: sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.15.2':
+    resolution: {integrity: sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.1':
+    resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.36.0':
+    resolution: {integrity: sha512-uhCbYtYynH30iZErszX78U+nR3pJU3RHGQ57NXy5QupD4SBVwDeU8TNBy+MjMngc1UyIW9noKqsRqfjQTBU2dw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.6':
+    resolution: {integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.3.5':
+    resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@humanfs/core@0.19.1':
+    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.7':
+    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/sarif@2.1.7':
+    resolution: {integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint@9.36.0:
+    resolution: {integrity: sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esquery@1.6.0:
+    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.3.3:
+    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+
+  fs-extra@11.3.2:
+    resolution: {integrity: sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==}
+    engines: {node: '>=14.14'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  glob@9.3.5:
+    resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globals@16.4.0:
+    resolution: {integrity: sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==}
+    engines: {node: '>=18'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  htmlhint@1.7.1:
+    resolution: {integrity: sha512-zasEL49C55zZj30n6KFSwlWPXCUxFcXNBGfupO8lQeFV5LAMAlvSloUWebXYsU3v2cSt2H4+AYx3wI6rUk4pmA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-yaml@4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  jsonfile@6.2.0:
+    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
+  minimatch@8.0.4:
+    resolution: {integrity: sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@4.2.8:
+    resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==}
+    engines: {node: '>=8'}
+
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  node-sarif-builder@3.2.0:
+    resolution: {integrity: sha512-kVIOdynrF2CRodHZeP/97Rh1syTUHBNiw17hUCIVhlhEsWlfJm19MuO56s4MdKbr22xWx6mzMnNAgXzVlIYM9Q==}
+    engines: {node: '>=18'}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  xml@1.0.1:
+    resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+snapshots:
+
+  '@eslint-community/eslint-utils@4.9.0(eslint@9.36.0)':
+    dependencies:
+      eslint: 9.36.0
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.1': {}
+
+  '@eslint/config-array@0.21.0':
+    dependencies:
+      '@eslint/object-schema': 2.1.6
+      debug: 4.4.3
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.3.1': {}
+
+  '@eslint/core@0.15.2':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.1':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.36.0': {}
+
+  '@eslint/object-schema@2.1.6': {}
+
+  '@eslint/plugin-kit@0.3.5':
+    dependencies:
+      '@eslint/core': 0.15.2
+      levn: 0.4.1
+
+  '@humanfs/core@0.19.1': {}
+
+  '@humanfs/node@0.16.7':
+    dependencies:
+      '@humanfs/core': 0.19.1
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/sarif@2.1.7': {}
+
+  acorn-jsx@5.3.2(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
+
+  acorn@8.15.0: {}
+
+  ajv@6.12.6:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  argparse@2.0.1: {}
+
+  async@3.2.6: {}
+
+  balanced-match@1.0.2: {}
+
+  brace-expansion@1.1.12:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
+
+  callsites@3.1.0: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  commander@11.1.0: {}
+
+  concat-map@0.0.1: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-is@0.1.4: {}
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint@9.36.0:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.36.0)
+      '@eslint-community/regexpp': 4.12.1
+      '@eslint/config-array': 0.21.0
+      '@eslint/config-helpers': 0.3.1
+      '@eslint/core': 0.15.2
+      '@eslint/eslintrc': 3.3.1
+      '@eslint/js': 9.36.0
+      '@eslint/plugin-kit': 0.3.5
+      '@humanfs/node': 0.16.7
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      eslint-visitor-keys: 4.2.1
+
+  esquery@1.6.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  esutils@2.0.3: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.3.3
+      keyv: 4.5.4
+
+  flatted@3.3.3: {}
+
+  fs-extra@11.3.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.0
+      universalify: 2.0.1
+
+  fs.realpath@1.0.0: {}
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob@9.3.5:
+    dependencies:
+      fs.realpath: 1.0.0
+      minimatch: 8.0.4
+      minipass: 4.2.8
+      path-scurry: 1.11.1
+
+  globals@14.0.0: {}
+
+  globals@16.4.0: {}
+
+  graceful-fs@4.2.11: {}
+
+  has-flag@4.0.0: {}
+
+  htmlhint@1.7.1:
+    dependencies:
+      async: 3.2.6
+      chalk: 4.1.2
+      commander: 11.1.0
+      glob: 9.3.5
+      is-glob: 4.0.3
+      node-sarif-builder: 3.2.0
+      strip-json-comments: 3.1.1
+      xml: 1.0.1
+
+  ignore@5.3.2: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  isexe@2.0.0: {}
+
+  js-yaml@4.1.0:
+    dependencies:
+      argparse: 2.0.1
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  jsonfile@6.2.0:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
+
+  lru-cache@10.4.3: {}
+
+  minimatch@3.1.2:
+    dependencies:
+      brace-expansion: 1.1.12
+
+  minimatch@8.0.4:
+    dependencies:
+      brace-expansion: 2.0.2
+
+  minipass@4.2.8: {}
+
+  minipass@7.1.2: {}
+
+  ms@2.1.3: {}
+
+  mustache@4.2.0: {}
+
+  natural-compare@1.4.0: {}
+
+  node-sarif-builder@3.2.0:
+    dependencies:
+      '@types/sarif': 2.1.7
+      fs-extra: 11.3.2
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.2
+
+  prelude-ls@1.2.1: {}
+
+  punycode@2.3.1: {}
+
+  resolve-from@4.0.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  strip-json-comments@3.1.1: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  universalify@2.0.1: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  word-wrap@1.2.5: {}
+
+  xml@1.0.1: {}
+
+  yocto-queue@0.1.0: {}

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,222 @@
+import { promises as fs } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Mustache from 'mustache';
+
+const ENTITY_MAP = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+Mustache.escape = (value) => {
+  const string = value == null ? '' : String(value);
+  return string.replace(/[&<>"']/g, (char) => ENTITY_MAP[char]);
+};
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__dirname, '..');
+
+const CONFIG_PATH = resolve(projectRoot, 'build.config.json');
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function readJson(filePath) {
+  const content = await fs.readFile(filePath, 'utf8');
+  return JSON.parse(content);
+}
+
+export function computeLanguageIndicators(maxLevel, value) {
+  const total = Number.isFinite(maxLevel) && maxLevel > 0 ? Math.floor(maxLevel) : 0;
+  const target = Number.isFinite(value) ? value : 0;
+  const steps = [];
+
+  if (total === 0) {
+    return steps;
+  }
+
+  let remaining = Math.min(Math.max(target, 0), total);
+
+  for (let index = 0; index < total; index += 1) {
+    if (remaining >= 1) {
+      steps.push({ classSuffix: ' item-full' });
+      remaining -= 1;
+    } else if (remaining >= 0.5) {
+      steps.push({ classSuffix: ' item-half' });
+      remaining = 0;
+    } else {
+      steps.push({ classSuffix: '' });
+      remaining = 0;
+    }
+  }
+
+  return steps;
+}
+
+export function createView({ localeConfig, translation, translations, config, profileImage, defaultLocale }) {
+  assert(translation?.meta?.lang, `Missing meta.lang for locale "${localeConfig.locale}"`);
+
+  const alternateLinks = config.locales.map((entry) => {
+    const translated = translations.get(entry.locale);
+    assert(translated?.meta?.lang, `Missing meta.lang for alternate locale "${entry.locale}"`);
+    return {
+      hreflang: translated.meta.lang,
+      href: entry.output,
+    };
+  });
+
+  const defaultEntry = config.locales.find((entry) => entry.locale === defaultLocale) ?? config.locales[0];
+  if (defaultEntry) {
+    alternateLinks.push({ hreflang: 'x-default', href: defaultEntry.output });
+  }
+
+  const languageOptions = (translation.languageSelector?.options ?? []).map((option) => {
+    const targetConfig = config.locales.find((entry) => entry.locale === option.value);
+    assert(targetConfig, `Missing locale config for language option "${option.value}"`);
+    const translated = translations.get(option.value);
+    assert(translated?.meta?.lang, `Missing translation for language option "${option.value}"`);
+    return {
+      ...option,
+      href: targetConfig.output,
+      hreflang: translated.meta.lang,
+      isActive: option.value === localeConfig.locale,
+    };
+  });
+
+  assert(languageOptions.length > 0, `No language options defined for locale "${localeConfig.locale}"`);
+
+  const experienceItems = (translation.experience?.items ?? []).map((item, index, array) => ({
+    ...item,
+    bullets: item.bullets ?? [],
+    isLast: index === array.length - 1,
+  }));
+
+  const techGroups = (translation.techStack?.groups ?? []).map((group, index, array) => ({
+    ...group,
+    items: group.items ?? [],
+    hasMargin: index !== array.length - 1,
+  }));
+
+  const educationItems = (translation.education?.items ?? []).map((item, index, array) => ({
+    ...item,
+    hasMargin: index !== array.length - 1,
+  }));
+
+  const languageItems = (translation.languages?.items ?? []).map((item, index, array) => ({
+    ...item,
+    hasMargin: index !== array.length - 1,
+    indicators: computeLanguageIndicators(translation.languages?.maxLevel ?? 10, item.level ?? 0),
+  }));
+
+  return {
+    meta: translation.meta,
+    alternateLinks,
+    languageSwitcher: {
+      label: translation.languageSelector?.label ?? '',
+      ariaLabel: translation.languageSelector?.ariaLabel ?? '',
+      options: languageOptions,
+    },
+    topBar: translation.topBar ?? { contactLabel: '', contactLink: '#' },
+    header: {
+      ...translation.header,
+      contact: translation.header?.contact ?? [],
+    },
+    profileImage,
+    summary: {
+      heading: translation.summary?.heading ?? '',
+      paragraphs: translation.summary?.paragraphs ?? [],
+    },
+    experience: {
+      heading: translation.experience?.heading ?? '',
+      items: experienceItems,
+    },
+    additionalExperience: {
+      heading: translation.additionalExperience?.heading ?? '',
+      items: translation.additionalExperience?.items ?? [],
+    },
+    techStack: {
+      heading: translation.techStack?.heading ?? '',
+      groups: techGroups,
+    },
+    softSkills: {
+      heading: translation.softSkills?.heading ?? '',
+      items: translation.softSkills?.items ?? [],
+    },
+    projects: {
+      heading: translation.projects?.heading ?? '',
+      items: translation.projects?.items ?? [],
+    },
+    education: {
+      heading: translation.education?.heading ?? '',
+      items: educationItems,
+    },
+    languages: {
+      heading: translation.languages?.heading ?? '',
+      items: languageItems,
+    },
+    interests: {
+      heading: translation.interests?.heading ?? '',
+      items: translation.interests?.items ?? [],
+    },
+  };
+}
+
+export async function loadBuildContext(configPath = CONFIG_PATH) {
+  const config = await readJson(configPath);
+  assert(Array.isArray(config.locales) && config.locales.length > 0, 'No locales configured');
+
+  const templatePath = resolve(projectRoot, config.template ?? 'templates/resume.mustache');
+  const template = await fs.readFile(templatePath, 'utf8');
+
+  const translations = new Map();
+  for (const localeConfig of config.locales) {
+    assert(localeConfig.locale, 'Locale config missing "locale"');
+    assert(localeConfig.source, `Locale "${localeConfig.locale}" missing source`);
+    const sourcePath = resolve(projectRoot, localeConfig.source);
+    const translation = await readJson(sourcePath);
+    translations.set(localeConfig.locale, translation);
+  }
+
+  const defaultLocale = translations.has(config.defaultLocale) ? config.defaultLocale : config.locales[0].locale;
+  const profileImage = config.assets?.profileImage ?? '';
+  assert(profileImage, 'Missing "assets.profileImage" in build.config.json');
+
+  return { config, template, translations, defaultLocale, profileImage };
+}
+
+export async function build() {
+  const { config, template, translations, defaultLocale, profileImage } = await loadBuildContext();
+
+  for (const localeConfig of config.locales) {
+    const translation = translations.get(localeConfig.locale);
+    assert(translation, `Missing translation for locale "${localeConfig.locale}"`);
+    const view = createView({
+      localeConfig,
+      translation,
+      translations,
+      config,
+      profileImage,
+      defaultLocale,
+    });
+
+    const rendered = Mustache.render(template, view);
+    const outputPath = resolve(projectRoot, localeConfig.output);
+    await fs.writeFile(outputPath, `${rendered.trimEnd()}\n`);
+    console.log(`✔ Built ${localeConfig.locale} → ${localeConfig.output}`);
+  }
+}
+
+const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (invokedDirectly) {
+  build().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/templates/resume.mustache
+++ b/templates/resume.mustache
@@ -1,0 +1,220 @@
+<!DOCTYPE html>
+<html lang="{{meta.lang}}">
+  <head>
+    <title>{{meta.title}}</title>
+
+    <!-- Meta -->
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="{{meta.description}}">
+    <meta name="author" content="Xiaoying Riley at 3rd Wave Media">
+    <link rel="shortcut icon" href="favicon.ico">
+
+    <!-- Alternate language versions -->
+    {{#alternateLinks}}
+    <link rel="alternate" hreflang="{{hreflang}}" href="{{href}}">
+    {{/alternateLinks}}
+
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
+
+    <!-- Bootstrap Icons -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.3/font/bootstrap-icons.css">
+
+    <!-- Theme CSS -->
+    <link id="theme-style" rel="stylesheet" href="assets/css/shine.css">
+  </head>
+
+  <body class="light-mode">
+    <div class="container-fluid">
+      <div class="main-content-wrapper">
+        <div class="container-fluid">
+          <div class="resume-wrapper mx-auto rounded-2">
+            <div class="resume-actions d-flex flex-column flex-sm-row align-items-center justify-content-center justify-content-sm-end gap-3 w-100 px-4 px-lg-5 pt-4 d-print-none">
+              <div class="language-switcher d-flex flex-column flex-sm-row align-items-center justify-content-center justify-content-sm-end gap-2">
+                <span class="text-uppercase small fw-semibold">{{languageSwitcher.label}}</span>
+                <div class="btn-group btn-group-sm" role="group" aria-label="{{languageSwitcher.ariaLabel}}">
+                  {{#languageSwitcher.options}}
+                  <a class="btn btn-outline-secondary btn-sm{{#isActive}} active{{/isActive}}" href="{{href}}" lang="{{value}}" hreflang="{{hreflang}}"{{#isActive}} aria-current="page"{{/isActive}}>{{shortLabel}}</a>
+                  {{/languageSwitcher.options}}
+                </div>
+              </div>
+              <a class="btn btn-primary" href="{{topBar.contactLink}}">{{topBar.contactLabel}}</a>
+            </div>
+            <div class="resume-header px-4 px-lg-5 py-4 py-lg-5">
+              <div class="resume-profile-holder text-center text-md-start d-flex flex-column flex-md-row align-items-center align-items-md-start gap-4 gap-lg-5">
+                <div class="flex-shrink-0">
+                  <img class="resume-profile-pic rounded-circle" src="{{profileImage}}" alt="{{header.profileImageAlt}}">
+                </div>
+                <div class="flex-grow-1 w-100">
+                  <h2 class="resume-name text-uppercase mb-2 mb-lg-3">{{header.name}}</h2>
+                  <div class="resume-role-title text-uppercase">{{header.role}}</div>
+                  <div class="resume-contact mt-4 mt-md-3">
+                    <ul class="resume-contact-list row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-3 list-unstyled mb-0">
+                      {{#header.contact}}
+                      <li class="col d-flex align-items-center gap-2 text-break">
+                        <i class="resume-contact-icon {{icon}} flex-shrink-0"></i>
+                        {{#href}}
+                        <a class="text-reset text-decoration-none" href="{{href}}">{{text}}</a>
+                        {{/href}}
+                        {{^href}}
+                        <span>{{text}}</span>
+                        {{/href}}
+                      </li>
+                      {{/header.contact}}
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="resume-body p-4 p-lg-5">
+              <div class="row g-4 g-lg-5">
+                <div class="col-main col-12 col-lg-8 pe-lg-4">
+                  <section class="resume-summary-section resume-section">
+                    <h3 class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-person me-2"></i>{{summary.heading}}</h3>
+                    <div class="resume-summary-desc">
+                      {{#summary.paragraphs}}
+                      <p>{{.}}</p>
+                      {{/summary.paragraphs}}
+                    </div>
+                  </section>
+
+                  <hr>
+
+                  <section class="resume-experience-section resume-section">
+                    <h3 class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-briefcase me-2"></i>{{experience.heading}}</h3>
+                    <div class="resume-timeline position-relative">
+                      {{#experience.items}}
+                      <article class="resume-timeline-item position-relative{{^isLast}} pb-5{{/isLast}}">
+                        <div class="resume-timeline-item-header mb-2">
+                          <div class="resume-position-meta d-flex justify-content-between mb-1">
+                            <div class="resume-position-time">{{time}}</div>
+                            <div class="resume-company-name">{{company}}</div>
+                          </div>
+                          <h3 class="resume-position-title mb-1">{{title}}</h3>
+                        </div>
+                        <div class="resume-timeline-item-desc">
+                          <ul class="resume-timeline-list">
+                            {{#bullets}}
+                            <li>{{.}}</li>
+                            {{/bullets}}
+                          </ul>
+                        </div>
+                      </article>
+                      {{/experience.items}}
+                    </div>
+                  </section>
+
+                  <hr>
+
+                  <section class="resume-section">
+                    <h3 class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-collection me-2"></i>{{additionalExperience.heading}}</h3>
+                    <ul class="list-unstyled mb-0">
+                      {{#additionalExperience.items}}
+                      <li><strong>{{title}}</strong>: {{description}}</li>
+                      {{/additionalExperience.items}}
+                    </ul>
+                  </section>
+                </div>
+                <div class="col-12 col-lg-4 ps-lg-4">
+                  <section class="resume-skills-section resume-section">
+                    <h3 class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-gear me-2"></i>{{techStack.heading}}</h3>
+                    <ul class="list-unstyled">
+                      {{#techStack.groups}}
+                      <li{{#hasMargin}} class="mb-3"{{/hasMargin}}>
+                        <div class="resume-skill-name">{{title}}</div>
+                        <div class="d-flex flex-wrap gap-2 mt-2">
+                          {{#items}}
+                          <span class="badge resume-skill-badge">{{.}}</span>
+                          {{/items}}
+                        </div>
+                      </li>
+                      {{/techStack.groups}}
+                    </ul>
+                  </section>
+
+                  <hr>
+
+                  <section class="resume-skills-section resume-section">
+                    <h3 class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-person-gear me-2"></i>{{softSkills.heading}}</h3>
+                    <ul class="list-inline">
+                      {{#softSkills.items}}
+                      <li class="list-inline-item"><span class="badge resume-skill-badge">{{.}}</span></li>
+                      {{/softSkills.items}}
+                    </ul>
+                  </section>
+
+                  <hr>
+
+                  <section class="resume-section">
+                    <h3 class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-collection-play me-2"></i>{{projects.heading}}</h3>
+                  {{#projects.items}}
+                    <div class="item">
+                      <h4 class="item-heading"><i class="item-icon bi bi-square-fill me-2"></i>{{name}}</h4>
+                      <div class="item-desc">{{description}}</div>
+                    </div>
+                  {{/projects.items}}
+                  </section>
+
+                  <hr>
+
+                  <section class="resume-educate-section resume-section">
+                    <h3 class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-book me-2"></i>{{education.heading}}</h3>
+                    <ul class="list-unstyled">
+                      {{#education.items}}
+                      <li{{#hasMargin}} class="mb-2"{{/hasMargin}}>
+                        <div class="resume-degree font-weight-bold">{{degree}}</div>
+                        <div class="resume-degree-org">{{organisation}}</div>
+                        <div class="resume-degree-time">{{time}}</div>
+                        <div class="resume-degree-desc">{{description}}</div>
+                      </li>
+                      {{/education.items}}
+                    </ul>
+                  </section>
+
+                  <hr>
+
+                  <section class="resume-lang-section resume-section">
+                    <h3 class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-translate me-2"></i>{{languages.heading}}</h3>
+                    <ul class="list-unstyled resume-lang-list">
+                      {{#languages.items}}
+                      <li{{#hasMargin}} class="mb-2"{{/hasMargin}}>
+                        <div class="resume-lang-name">{{name}}</div>
+                        <div class="resume-level-indicator row gx-0 flex-nowrap">
+                          {{#indicators}}
+                          <div class="col"><span class="item{{classSuffix}}"></span></div>
+                          {{/indicators}}
+                        </div>
+                      </li>
+                      {{/languages.items}}
+                    </ul>
+                  </section>
+
+                  <hr>
+
+                  <section class="resume-interests-section resume-section">
+                    <h3 class="resume-section-heading text-uppercase py-2 py-lg-3"><i class="resume-section-heading-icon bi bi-sun me-2"></i>{{interests.heading}}</h3>
+                    <ul class="list-inline">
+                      {{#interests.items}}
+                      <li class="list-inline-item"><span class="badge resume-skill-badge">{{.}}</span></li>
+                      {{/interests.items}}
+                    </ul>
+                  </section>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <footer class="footer text-center py-4 d-print-none">
+      <!--/* This template is free as long as you keep the footer attribution link. If you'd like to use the template without the attribution link, you can buy the commercial license via our website: themes.3rdwavemedia.com Thank you for your support. :) */-->
+      <small class="copyright">Designed with <span class="sr-only">love</span><i class="bi bi-heart-fill" style="color:#fe655c"></i> by <a class="theme-link" href="http://themes.3rdwavemedia.com" target="_blank">Xiaoying Riley</a> for developers</small>
+    </footer>
+  </body>
+</html>

--- a/tests/build.test.mjs
+++ b/tests/build.test.mjs
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import Mustache from 'mustache';
+
+import {
+  computeLanguageIndicators,
+  createView,
+  loadBuildContext,
+} from '../scripts/build.mjs';
+
+const buildContextPromise = loadBuildContext();
+
+test('computeLanguageIndicators maps fractional proficiency to display steps', () => {
+  const steps = computeLanguageIndicators(4, 2.5);
+  assert.equal(steps.length, 4);
+  assert.deepEqual(
+    steps.map((step) => step.classSuffix),
+    [' item-full', ' item-full', ' item-half', ''],
+  );
+
+  const empty = computeLanguageIndicators(0, 3);
+  assert.deepEqual(empty, []);
+
+  const nonNegative = computeLanguageIndicators(5, -2);
+  assert.equal(nonNegative.length, 5);
+  assert.ok(nonNegative.every((step) => step.classSuffix === ''));
+});
+
+test('createView adds cross-linked language options and structural defaults', async () => {
+  const { config, translations, defaultLocale, profileImage } = await buildContextPromise;
+
+  for (const localeConfig of config.locales) {
+    const translation = translations.get(localeConfig.locale);
+    assert.ok(translation, `expected translation for ${localeConfig.locale}`);
+
+    const view = createView({
+      localeConfig,
+      translation,
+      translations,
+      config,
+      profileImage,
+      defaultLocale,
+    });
+
+    assert.equal(view.meta.lang, translation.meta.lang);
+
+    const alternateHreflangs = new Set(view.alternateLinks.map((link) => link.hreflang));
+    for (const entry of config.locales) {
+      const alternate = translations.get(entry.locale);
+      assert.ok(alternate, `expected alternate translation for ${entry.locale}`);
+      assert.ok(
+        alternateHreflangs.has(alternate.meta.lang),
+        `missing alternate link for locale ${entry.locale}`,
+      );
+    }
+    assert.ok(alternateHreflangs.has('x-default'), 'missing x-default alternate');
+
+    assert.equal(
+      view.languageSwitcher.options.length,
+      translation.languageSelector.options.length,
+    );
+
+    for (const option of view.languageSwitcher.options) {
+      const targetConfig = config.locales.find((entry) => entry.locale === option.value);
+      const targetTranslation = translations.get(option.value);
+      assert.ok(targetConfig, `language option ${option.value} missing locale config`);
+      assert.ok(targetTranslation, `language option ${option.value} missing translation`);
+
+      assert.equal(option.href, targetConfig.output);
+      assert.equal(option.hreflang, targetTranslation.meta.lang);
+      assert.equal(option.isActive, option.value === localeConfig.locale);
+    }
+
+    const experienceItems = view.experience.items;
+    assert.ok(Array.isArray(experienceItems));
+    experienceItems.forEach((item, index) => {
+      assert.ok(Array.isArray(item.bullets));
+      const expectedLast = index === experienceItems.length - 1;
+      assert.equal(item.isLast, expectedLast);
+    });
+
+    const maxLanguageLevel = translation.languages?.maxLevel ?? 0;
+    view.languages.items.forEach((language) => {
+      assert.equal(language.indicators.length, maxLanguageLevel);
+    });
+  }
+});
+
+test('rendered markup keeps the main résumé sections intact', async () => {
+  const { config, translations, defaultLocale, profileImage, template } = await buildContextPromise;
+
+  const requiredFragments = [
+    '<section class="resume-summary-section',
+    '<section class="resume-experience-section',
+    '<section class="resume-skills-section',
+    '<section class="resume-lang-section',
+    '<footer class="footer',
+  ];
+
+  for (const localeConfig of config.locales) {
+    const translation = translations.get(localeConfig.locale);
+    const view = createView({
+      localeConfig,
+      translation,
+      translations,
+      config,
+      profileImage,
+      defaultLocale,
+    });
+
+    const html = Mustache.render(template, view);
+    assert.ok(html.includes(`<html lang="${translation.meta.lang}">`));
+
+    for (const fragment of requiredFragments) {
+      assert.ok(
+        html.includes(fragment),
+        `expected fragment "${fragment}" in ${localeConfig.output}`,
+      );
+    }
+
+    for (const option of view.languageSwitcher.options) {
+      assert.ok(
+        html.includes(`href="${option.href}"`),
+        `expected language link for ${option.value} in ${localeConfig.output}`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- export build helpers and add a loadBuildContext utility so the static renderer can be exercised in isolation
- add a Node --test suite that verifies language links and key résumé sections stay intact
- expand AGENTS/README guidance about rerunning pnpm build/pnpm test and point the package.json test script at node --test

## Testing
- pnpm build
- pnpm lint:fix
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d017551e5c832c924f53151582718c