### PR TITLE
ci: publish resume pdf artifact

### DIFF
--- a/.github/workflows/resume-pdf.yml
+++ b/.github/workflows/resume-pdf.yml
@@ -1,0 +1,46 @@
+name: Build resume PDF
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  generate:
+    name: Generate resume PDF artifact
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.13.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build static resume pages
+        run: pnpm build
+
+      - name: Install Playwright Chromium browser
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Render resume PDF
+        run: pnpm pdf
+
+      - name: Upload resume PDF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: resume-pdf
+          path: artifacts/resume.pdf
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
 config.codekit3
 node_modules/
+resume.pdf
+artifacts/
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "node scripts/build.mjs",
     "lint:fix": "eslint --fix assets/js && htmlhint index.html index.de.html",
-    "test": "node --test"
+    "test": "node --test",
+    "pdf": "node scripts/generate-pdf.mjs --output artifacts/resume.pdf"
   },
   "keywords": [],
   "author": "",
@@ -16,6 +17,7 @@
     "eslint": "^9.36.0",
     "globals": "^16.4.0",
     "htmlhint": "^1.7.1",
-    "mustache": "^4.2.0"
+    "mustache": "^4.2.0",
+    "playwright": "^1.55.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       mustache:
         specifier: ^4.2.0
         version: 4.2.0
+      playwright:
+        specifier: ^1.55.0
+        version: 1.55.0
 
 packages:
 
@@ -233,6 +236,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
@@ -373,6 +381,16 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  playwright-core@1.55.0:
+    resolution: {integrity: sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.55.0:
+    resolution: {integrity: sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -652,6 +670,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
@@ -784,6 +805,14 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.2
+
+  playwright-core@1.55.0: {}
+
+  playwright@1.55.0:
+    dependencies:
+      playwright-core: 1.55.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   prelude-ls@1.2.1: {}
 

--- a/scripts/generate-pdf.mjs
+++ b/scripts/generate-pdf.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+import { chromium } from 'playwright';
+import { readFile, mkdir } from 'node:fs/promises';
+import { dirname, extname, basename, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const args = process.argv.slice(2);
+
+let inputArg;
+let outputArg;
+const positional = [];
+
+for (let index = 0; index < args.length; index += 1) {
+  const value = args[index];
+
+  if (value === '--input' || value === '-i') {
+    inputArg = args[index + 1];
+    index += 1;
+    continue;
+  }
+
+  if (value.startsWith('--input=')) {
+    inputArg = value.slice('--input='.length);
+    continue;
+  }
+
+  if (value === '--output' || value === '-o') {
+    outputArg = args[index + 1];
+    index += 1;
+    continue;
+  }
+
+  if (value.startsWith('--output=')) {
+    outputArg = value.slice('--output='.length);
+    continue;
+  }
+
+  if (value.startsWith('-')) {
+    console.warn(`Ignoring unknown option: ${value}`);
+    continue;
+  }
+
+  positional.push(value);
+}
+
+if (!inputArg && positional.length > 0) {
+  [inputArg] = positional;
+}
+
+if (!outputArg && positional.length > 1) {
+  outputArg = positional[1];
+}
+
+async function resolveDefaultInput() {
+  try {
+    const raw = await readFile(new URL('../build.config.json', import.meta.url), 'utf8');
+    const config = JSON.parse(raw);
+    if (!config?.locales || !Array.isArray(config.locales)) {
+      return 'index.html';
+    }
+
+    const defaultLocale = config.defaultLocale;
+    const fallback = config.locales[0];
+    const matching = config.locales.find((entry) => entry.locale === defaultLocale);
+    return (matching ?? fallback)?.output ?? 'index.html';
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : error;
+    console.warn('Could not determine default locale from build.config.json. Falling back to index.html.', reason);
+    return 'index.html';
+  }
+}
+
+const inputRelative = inputArg ?? await resolveDefaultInput();
+const defaultOutputName = inputArg
+  ? `${basename(inputRelative, extname(inputRelative)) || 'resume'}.pdf`
+  : 'resume.pdf';
+const outputRelative = outputArg ?? defaultOutputName;
+
+const inputPath = resolve(process.cwd(), inputRelative);
+const outputPath = resolve(process.cwd(), outputRelative);
+
+await mkdir(dirname(outputPath), { recursive: true });
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1240, height: 1754 } });
+
+try {
+  const url = pathToFileURL(inputPath).href;
+  await page.goto(url, { waitUntil: 'networkidle' });
+  await page.emulateMedia({ media: 'screen' });
+  await page.waitForLoadState('networkidle');
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+  });
+  await page.waitForTimeout(300);
+
+  await page.pdf({
+    path: outputPath,
+    format: 'A4',
+    printBackground: true,
+    preferCSSPageSize: true,
+    margin: { top: '0', right: '0', bottom: '0', left: '0' }
+  });
+
+  console.log(`Saved resume PDF to ${outputPath}`);
+} catch (error) {
+  console.error('Failed to generate resume PDF.', error);
+  process.exitCode = 1;
+} finally {
+  await browser.close();
+}


### PR DESCRIPTION
## Summary
- add a Playwright-based script and pnpm command to render the default resume page to PDF
- ignore local resume artifacts to keep the workspace clean
- introduce a GitHub Actions workflow that builds the site, generates the PDF, and uploads it on pushes to main

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d045993eb4832caa5a910d22bae1e7